### PR TITLE
iPad optimizations [draft]

### DIFF
--- a/BuildConfig/Base.xcconfig
+++ b/BuildConfig/Base.xcconfig
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-ARCHS = armv7 arm64
+ARCHS = arm64
 SDKROOT = iphoneos
 
 MACOSX_DEPLOYMENT_TARGET = 10.7
@@ -12,7 +12,7 @@ CODE_SIGN_IDENTITY[sdk=iphoneos*] = iPhone Developer
 
 IPHONEOS_DEPLOYMENT_TARGET = 8.0
 
-TARGETED_DEVICE_FAMILY = 1 // iPhone
+TARGETED_DEVICE_FAMILY = 1,2 // iPhone, iPad
 
 ALWAYS_SEARCH_USER_PATHS = NO
 USER_HEADER_SEARCH_PATHS = 

--- a/Mumble.xcodeproj/project.pbxproj
+++ b/Mumble.xcodeproj/project.pbxproj
@@ -1310,7 +1310,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				PROVISIONING_PROFILE = "";
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -1320,7 +1320,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				PROVISIONING_PROFILE = "";
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -1464,7 +1464,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				PROVISIONING_PROFILE = "";
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = AppStore;
 		};
@@ -1472,6 +1472,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 285E2A62150D729B008AE185 /* BetaDist.xcconfig */;
 			buildSettings = {
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = BetaDist;
 		};
@@ -1481,7 +1482,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				PROVISIONING_PROFILE = "";
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = BetaDist;
 		};
@@ -1497,6 +1498,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 285E2A64150D729B008AE185 /* Release.xcconfig */;
 			buildSettings = {
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -43,7 +43,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -106,6 +106,9 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
These are a few minimal changes to get a somewhat working UI when using mumble on an iOS tablet. Basically this allows to rotate the screen and, split view etc. 

The source code itself already included some specific iPad switches, which were not used as the info.plist file had only a `UIInterfaceOrientationPortrait` entry in the `UISupportedInterfaceOrientations` array. 

A proper solution would be probably a proper SplitViewController etc. – but this was the first time after 5 years that I last looked at ObjectiveC source... :-) 


Demo:

https://user-images.githubusercontent.com/40266/105707298-00f4e980-5f13-11eb-8bbd-16e11d4fbdd8.mp4






If you want to test this on your own device, and have no Apple Developer Account: 
* see https://ionicframework.com/blog/deploying-to-a-device-without-an-apple-developer-account/ how to configure XCode and setup your "Free Personal Team"
* checkout this branch
* change the app bundle id to something other e.g. `tld.your-domain.Mumble`
* set the build system to legacy, c.f. https://github.com/mumble-voip/mumble-iphoneos/issues/131#issuecomment-760719341
* allow apps signed with these provisioning profile in your iOS device's settings