### PR TITLE
Enable ARC for (most of) the app

### DIFF
--- a/Dependencies/MKNumberBadgeView/MKNumberBadgeView.m
+++ b/Dependencies/MKNumberBadgeView/MKNumberBadgeView.m
@@ -86,16 +86,6 @@
 	self.backgroundColor = [UIColor clearColor];
 }
 
-- (void)dealloc 
-{
-	[_font release];
-	[_fillColor release];
-	[_strokeColor release];
-	[_textColor release];
-	
-    [super dealloc];
-}
-
 
 - (void)drawRect:(CGRect)rect 
 {

--- a/Dependencies/gtm/GTMStringEncoding.m
+++ b/Dependencies/gtm/GTMStringEncoding.m
@@ -89,22 +89,20 @@ GTM_INLINE int lcm(int a, int b) {
 }
 
 + (id)stringEncodingWithString:(NSString *)string {
-  return [[[self alloc] initWithString:string] autorelease];
+  return [[self alloc] initWithString:string];
 }
 
 - (id)initWithString:(NSString *)string {
   if ((self = [super init])) {
-    charMapData_ = [[string dataUsingEncoding:NSASCIIStringEncoding] retain];
+    charMapData_ = [string dataUsingEncoding:NSASCIIStringEncoding];
     if (!charMapData_) {
       _GTMDevLog(@"Unable to convert string to ASCII");
-      [self release];
       return nil;
     }
     charMap_ = (char *)[charMapData_ bytes];
     NSUInteger length = [charMapData_ length];
     if (length < 2 || length > 128 || length & (length - 1)) {
       _GTMDevLog(@"Length not a power of 2 between 2 and 128");
-      [self release];
       return nil;
     }
 
@@ -112,7 +110,6 @@ GTM_INLINE int lcm(int a, int b) {
     for (unsigned int i = 0; i < length; i++) {
       if (reverseCharMap_[(int)charMap_[i]] != kUnknownChar) {
         _GTMDevLog(@"Duplicate character at pos %d", i);
-        [self release];
         return nil;
       }
       reverseCharMap_[(int)charMap_[i]] = i;
@@ -124,11 +121,6 @@ GTM_INLINE int lcm(int a, int b) {
     padLen_ = lcm(8, shift_) / shift_;
   }
   return self;
-}
-
-- (void)dealloc {
-  [charMapData_ release];
-  [super dealloc];
 }
 
 - (NSString *)description {
@@ -217,8 +209,8 @@ GTM_INLINE int lcm(int a, int b) {
   _GTMDevAssert(outPos == outLen, @"Underflowed output buffer");
   [outData setLength:outPos];
 
-  return [[[NSString alloc] initWithData:outData
-                                encoding:NSASCIIStringEncoding] autorelease];
+  return [[NSString alloc] initWithData:outData
+                                encoding:NSASCIIStringEncoding];
 }
 
 - (NSString *)encodeString:(NSString *)inString {
@@ -282,8 +274,8 @@ GTM_INLINE int lcm(int a, int b) {
 
 - (NSString *)stringByDecoding:(NSString *)inString {
   NSData *ret = [self decode:inString];
-  return [[[NSString alloc] initWithData:ret
-                                encoding:NSUTF8StringEncoding] autorelease];
+  return [[NSString alloc] initWithData:ret
+                                encoding:NSUTF8StringEncoding];
 }
 
 @end

--- a/Mumble.xcodeproj/project.pbxproj
+++ b/Mumble.xcodeproj/project.pbxproj
@@ -23,9 +23,9 @@
 		28234D6013F09148006B830D /* talkbutton_off@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 28234D5C13F09148006B830D /* talkbutton_off@2x.png */; };
 		28234D6113F09148006B830D /* talkbutton_on.png in Resources */ = {isa = PBXBuildFile; fileRef = 28234D5D13F09148006B830D /* talkbutton_on.png */; };
 		28234D6213F09148006B830D /* talkbutton_on@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 28234D5E13F09148006B830D /* talkbutton_on@2x.png */; };
-		282F6A2513620BD5008F555B /* MUCertificateController.m in Sources */ = {isa = PBXBuildFile; fileRef = 282F6A2413620BD5008F555B /* MUCertificateController.m */; };
+		282F6A2513620BD5008F555B /* MUCertificateController.m in Sources */ = {isa = PBXBuildFile; fileRef = 282F6A2413620BD5008F555B /* MUCertificateController.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		283363DB13EF154C00A04F04 /* MUAudioTransmissionPreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 283363DA13EF154C00A04F04 /* MUAudioTransmissionPreferencesViewController.m */; };
-		2836767D1525053A0015958E /* MUCertificateChainBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 2836767C1525053A0015958E /* MUCertificateChainBuilder.m */; };
+		2836767D1525053A0015958E /* MUCertificateChainBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 2836767C1525053A0015958E /* MUCertificateChainBuilder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		2838EA0F129316C200035C5D /* MUCertificatePreferencesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2838EA0E129316C200035C5D /* MUCertificatePreferencesViewController.m */; };
 		2843040A16BF25590025A783 /* MumbleMenuButton.png in Resources */ = {isa = PBXBuildFile; fileRef = 2843040816BF25590025A783 /* MumbleMenuButton.png */; };
 		2843040B16BF25590025A783 /* MumbleMenuButton@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 2843040916BF25590025A783 /* MumbleMenuButton@2x.png */; };
@@ -100,8 +100,8 @@
 		28851B95147DC97E00088C4F /* MULegalViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28851B93147DC97D00088C4F /* MULegalViewController.xib */; };
 		288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
 		288B55E01252903300563A28 /* MUServerCertificateTrustViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 288B55DF1252903300563A28 /* MUServerCertificateTrustViewController.m */; };
-		288D6B60123D08EE00D37EDE /* MUCertificateViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 288D6B5F123D08EE00D37EDE /* MUCertificateViewController.m */; };
-		28942D7C12456F9200C63A07 /* MUCertificateCreationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 28942D7B12456F9200C63A07 /* MUCertificateCreationView.m */; };
+		288D6B60123D08EE00D37EDE /* MUCertificateViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 288D6B5F123D08EE00D37EDE /* MUCertificateViewController.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		28942D7C12456F9200C63A07 /* MUCertificateCreationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 28942D7B12456F9200C63A07 /* MUCertificateCreationView.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		28990AB1132FDA540034B406 /* libMumbleKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 28990AB0132FDA540034B406 /* libMumbleKit.a */; };
 		289CBA18125693040015E58E /* MUServerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 289CBA17125693040015E58E /* MUServerViewController.m */; };
 		289D254C11BC28BC00E39F2C /* MULanServerListController.m in Sources */ = {isa = PBXBuildFile; fileRef = 289D254B11BC28BC00E39F2C /* MULanServerListController.m */; };
@@ -126,7 +126,7 @@
 		28BE99A018CFF03D00910551 /* LeftBalloonSelectedMono@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 28BE999C18CFF03D00910551 /* LeftBalloonSelectedMono@2x.png */; };
 		28BE99A118CFF03D00910551 /* RightBalloonSelectedMono.png in Resources */ = {isa = PBXBuildFile; fileRef = 28BE999D18CFF03D00910551 /* RightBalloonSelectedMono.png */; };
 		28BE99A218CFF03D00910551 /* RightBalloonSelectedMono@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 28BE999E18CFF03D00910551 /* RightBalloonSelectedMono@2x.png */; };
-		28BF81D2139AFFD50078B722 /* MUCertificateDiskImportViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28BF81D1139AFFD50078B722 /* MUCertificateDiskImportViewController.m */; };
+		28BF81D2139AFFD50078B722 /* MUCertificateDiskImportViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28BF81D1139AFFD50078B722 /* MUCertificateDiskImportViewController.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		28C6EF0A11BBF38100E426C8 /* MUCountryServerListController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28C6EF0911BBF38100E426C8 /* MUCountryServerListController.m */; };
 		28D963961639B9E4002A9E73 /* iconpad.png in Resources */ = {isa = PBXBuildFile; fileRef = 28D963951639B9E4002A9E73 /* iconpad.png */; };
 		28D963981639B9E8002A9E73 /* iconpad@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 28D963971639B9E8002A9E73 /* iconpad@2x.png */; };
@@ -1451,6 +1451,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 285E2A60150D729B008AE185 /* AppStore.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = AppStore;
 		};
@@ -1468,6 +1469,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 285E2A62150D729B008AE185 /* BetaDist.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = BetaDist;
 		};
@@ -1485,6 +1487,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 285E2A63150D729B008AE185 /* Debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
@@ -1493,6 +1496,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 285E2A64150D729B008AE185 /* Release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = Release;
 		};

--- a/Source/Classes/MUAccessTokenViewController.m
+++ b/Source/Classes/MUAccessTokenViewController.m
@@ -23,16 +23,10 @@
 
 - (id) initWithServerModel:(MKServerModel *)model {
     if ((self = [super initWithStyle:UITableViewStylePlain])) {
-        _model = [model retain];
+        _model = model;
         _editingRow = -1;
     }
     return self;
-}
-
-- (void) dealloc {
-    [_model release];
-    [_editingCell release];
-    [super dealloc];
 }
 
 #pragma mark - View lifecycle
@@ -57,11 +51,9 @@
 
     UIBarButtonItem *addButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd target:self action:@selector(addButtonClicked:)];
     [[self navigationItem] setRightBarButtonItem:addButton];
-    [addButton release];
     
     UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneButtonClicked:)];
     [[self navigationItem] setLeftBarButtonItem:doneButton];
-    [doneButton release];
     
     
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -83,7 +75,6 @@
     [_model setAccessTokens:_tokens];
 
     [MUDatabase storeAccessTokens:_tokens forServerWithHostname:[_model hostname] port:[_model port]];
-    [_tokens release];
 }
 
 - (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
@@ -104,7 +95,7 @@
     static NSString *CellIdentifier = @"AccessTokenCell";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
     }
     if ([indexPath row] == _editingRow) {
         return _editingCell;
@@ -149,7 +140,6 @@
 - (void) editItemAtIndex:(NSInteger)row {
     _editingRow = row;
 
-    [_tokenValue release];
     _tokenValue = [[_tokens objectAtIndex:row] copy];
 
     _editingCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"AccessTokenEditingCell"];
@@ -169,7 +159,6 @@
     [editingField setText:_tokenValue];
     [editingField setReturnKeyType:UIReturnKeyDone];
     [[_editingCell contentView] addSubview:editingField];
-    [editingField release];
 
     [editingField setTranslatesAutoresizingMaskIntoConstraints:NO];
 
@@ -206,19 +195,16 @@
 }
 
 - (void) textFieldDidChange:(UITextField *)sender {
-    [_tokenValue release];
     _tokenValue = [[sender text] copy];
 }
 
 - (void) textFieldDidEndOnExit:(UITextField *)sender {
     [sender resignFirstResponder];
     [_tokens replaceObjectAtIndex:_editingRow withObject:_tokenValue];
-    [_tokenValue release];
     _tokenValue = nil;
     NSInteger row = _editingRow;
     _editingRow = -1;
     [self.tableView reloadRowsAtIndexPaths:[NSArray arrayWithObject:[NSIndexPath indexPathForRow:row inSection:0]] withRowAnimation:UITableViewRowAnimationNone];
-    [_editingCell release];
     _editingCell = nil;
 }
 

--- a/Source/Classes/MUAdvancedAudioPreferencesViewController.m
+++ b/Source/Classes/MUAdvancedAudioPreferencesViewController.m
@@ -89,7 +89,7 @@
     static NSString *CellIdentifier = @"MUAdvancedAudioPreferencesCell";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:CellIdentifier] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:CellIdentifier];
     }
     
     cell.detailTextLabel.text = nil;
@@ -115,7 +115,7 @@
         if ([indexPath row] == 0) {
             cell.textLabel.text = NSLocalizedString(@"Preprocessing", nil);
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
-            UISwitch *preprocSwitch = [[[UISwitch alloc] init] autorelease];
+            UISwitch *preprocSwitch = [[UISwitch alloc] init];
             preprocSwitch.onTintColor = [UIColor blackColor];
             preprocSwitch.on = [defaults boolForKey:@"AudioPreprocessor"];
             [preprocSwitch addTarget:self action:@selector(preprocessingChanged:) forControlEvents:UIControlEventValueChanged];
@@ -124,7 +124,7 @@
             if ([defaults boolForKey:@"AudioPreprocessor"]) {
                 cell.textLabel.text = NSLocalizedString(@"Echo Cancellation", nil);
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
-                UISwitch *echoCancelSwitch = [[[UISwitch alloc] init] autorelease];
+                UISwitch *echoCancelSwitch = [[UISwitch alloc] init];
                 echoCancelSwitch.onTintColor = [UIColor blackColor];
                 echoCancelSwitch.on = [defaults boolForKey:@"AudioEchoCancel"];
                 echoCancelSwitch.enabled = [[MKAudio sharedAudio] echoCancellationAvailable];
@@ -136,7 +136,7 @@
             } else {
                 cell.textLabel.text = NSLocalizedString(@"Mic Boost", nil);
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
-                UISlider *slider = [[[UISlider alloc] init] autorelease];
+                UISlider *slider = [[UISlider alloc] init];
                 [slider setMaximumValue:2.0f];
                 [slider setMinimumValue:0.0f];
                 float boost = [defaults floatForKey:@"AudioMicBoost"];
@@ -164,7 +164,7 @@
         } else if ([indexPath row] == 1) {
             cell.textLabel.text = NSLocalizedString(@"Speakerphone Mode", nil);
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
-            UISwitch *speakerPhoneSwitch = [[[UISwitch alloc] init] autorelease];
+            UISwitch *speakerPhoneSwitch = [[UISwitch alloc] init];
             speakerPhoneSwitch.onTintColor = [UIColor blackColor];
             speakerPhoneSwitch.on = [defaults boolForKey:@"AudioSpeakerPhoneMode"];
             speakerPhoneSwitch.enabled = YES;
@@ -175,7 +175,7 @@
         if ([indexPath row] == 0) {
             cell.textLabel.text = NSLocalizedString(@"Force CELT Mode", nil);
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
-            UISwitch *celtSwitch = [[[UISwitch alloc] init] autorelease];
+            UISwitch *celtSwitch = [[UISwitch alloc] init];
             celtSwitch.onTintColor = [UIColor blackColor];
             celtSwitch.on = [defaults boolForKey:@"AudioOpusCodecForceCELTMode"];
             celtSwitch.enabled = YES;
@@ -247,11 +247,9 @@
     if ([indexPath section] == 0 && [indexPath row] == 0) {
         MUAudioQualityPreferencesViewController *audioQual = [[MUAudioQualityPreferencesViewController alloc] init];
         [self.navigationController pushViewController:audioQual animated:YES];
-        [audioQual release];
     } else if ([indexPath section] == 2 && [indexPath row] == 0) {
         MUAudioSidetonePreferencesViewController *sidetonePrefs = [[MUAudioSidetonePreferencesViewController alloc] init];
         [self.navigationController pushViewController:sidetonePrefs animated:YES];
-        [sidetonePrefs release];
     }
 }
 

--- a/Source/Classes/MUApplicationDelegate.m
+++ b/Source/Classes/MUApplicationDelegate.m
@@ -115,11 +115,9 @@
     if (idiom == UIUserInterfaceIdiomPad) {
         welcomeScreen = [[MUWelcomeScreenPad alloc] init];
         [_navigationController pushViewController:welcomeScreen animated:YES];
-        [welcomeScreen release];
     } else {
         welcomeScreen = [[MUWelcomeScreenPhone alloc] init];
         [_navigationController pushViewController:welcomeScreen animated:YES];
-        [welcomeScreen release];
     }
     
     [_window setRootViewController:_navigationController];
@@ -156,15 +154,6 @@
 
 - (void) applicationWillTerminate:(UIApplication *)application {
     [MUDatabase teardown];
-}
-
-- (void) dealloc {
-#ifdef MUMBLE_BETA_DIST
-    [_verCheck release];
-#endif
-    [_navigationController release];
-    [_window release];
-    [super dealloc];
 }
 
 - (void) setupAudio {
@@ -260,7 +249,6 @@
 - (void) forceKeyboardLoad {
     UITextField *textField = [[UITextField alloc] initWithFrame:CGRectZero];
     [_window addSubview:textField];
-    [textField release];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [textField becomeFirstResponder];
 }

--- a/Source/Classes/MUAudioBarView.m
+++ b/Source/Classes/MUAudioBarView.m
@@ -24,7 +24,7 @@
         _value = 0.5f;
         _min = 0.0f;
         _max = 1.0f;
-        _timer = [[NSTimer timerWithTimeInterval:1/60.0f target:self selector:@selector(tickTock) userInfo:nil repeats:YES] retain];
+        _timer = [NSTimer timerWithTimeInterval:1/60.0f target:self selector:@selector(tickTock) userInfo:nil repeats:YES];
         [[NSRunLoop mainRunLoop] addTimer:_timer forMode:NSRunLoopCommonModes];
     }
     return self;
@@ -32,8 +32,6 @@
 
 - (void) dealloc {
     [_timer invalidate];
-    [_timer release];
-    [super dealloc];
 }
 
 - (void) setBelow:(CGFloat)below {

--- a/Source/Classes/MUAudioBarViewCell.m
+++ b/Source/Classes/MUAudioBarViewCell.m
@@ -28,7 +28,6 @@
             self.backgroundView.layer.cornerRadius = 8.0f;
         }
         self.backgroundColor = [UIColor clearColor];
-        [audioBarView release];
     }
     return self;
 }

--- a/Source/Classes/MUAudioMixerDebugViewController.m
+++ b/Source/Classes/MUAudioMixerDebugViewController.m
@@ -20,29 +20,21 @@
     return self;
 }
 
-- (void) dealloc {
-    [_mixerInfo release];
-    [super dealloc];
-}
-
 - (void) viewWillAppear:(BOOL)animated {
     [[self navigationItem] setTitle:@"Mixer Debug"];
     
     UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneDebugging:)];
     [[self navigationItem] setRightBarButtonItem:doneButton];
-    [doneButton release];
     
-    _timer = [[NSTimer scheduledTimerWithTimeInterval:0.001 target:self selector:@selector(updateMixerInfo:) userInfo:nil repeats:YES] retain];
+    _timer = [NSTimer scheduledTimerWithTimeInterval:0.001 target:self selector:@selector(updateMixerInfo:) userInfo:nil repeats:YES];
     [self updateMixerInfo:self];
 }
 
 - (void) viewWillDisappear:(BOOL)animated {
     [_timer invalidate];
-    [_timer release];
 }
 
 - (void) updateMixerInfo:(id)sender {
-    [_mixerInfo release];
     _mixerInfo = [[MKAudio sharedAudio] copyAudioOutputMixerDebugInfo];
     [[self tableView] reloadData];
 }
@@ -69,7 +61,7 @@
     static NSString *CellIdentifier = @"AudioMixerDebugCell";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:CellIdentifier] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:CellIdentifier];
     }
     
     if (indexPath.section == 0) { // Meta
@@ -79,7 +71,6 @@
             NSDate *date = [_mixerInfo objectForKey:@"last-update"];
             cell.textLabel.text = @"Last Updated";
             cell.detailTextLabel.text = [fmt stringFromDate:date];
-            [fmt release];
         }
     }
     

--- a/Source/Classes/MUAudioQualityPreferencesViewController.m
+++ b/Source/Classes/MUAudioQualityPreferencesViewController.m
@@ -61,7 +61,7 @@
     static NSString *CellIdentifier = @"MUAudioQualityPreferencesCell";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:CellIdentifier] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:CellIdentifier];
     }
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
@@ -74,28 +74,28 @@
             cell.textLabel.text = NSLocalizedString(@"Low", nil);
             cell.detailTextLabel.text = NSLocalizedString(@"16 kbit/s, 60 ms audio per packet", nil);
             if ([[defaults stringForKey:@"AudioQualityKind"] isEqualToString:@"low"]) {
-                cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+                cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
                 cell.textLabel.textColor = [MUColor selectedTextColor];
             }
         } else if ([indexPath row] == 1) {
             cell.textLabel.text = NSLocalizedString(@"Balanced", nil);
             cell.detailTextLabel.text = NSLocalizedString(@"40 kbit/s, 20 ms audio per packet", nil);
             if ([[defaults stringForKey:@"AudioQualityKind"] isEqualToString:@"balanced"]) {
-                cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+                cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
                 cell.textLabel.textColor = [MUColor selectedTextColor];
             }
         } else if ([indexPath row] == 2) {
             cell.textLabel.text = NSLocalizedString(@"High", nil);
             cell.detailTextLabel.text = NSLocalizedString(@"72 kbit/s, 10 ms audio per packet", nil);
             if ([[defaults stringForKey:@"AudioQualityKind"] isEqualToString:@"high"]) {
-                cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+                cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
                 cell.textLabel.textColor = [MUColor selectedTextColor];
             }
         } else if ([indexPath row] == 3) {
             cell.textLabel.text = NSLocalizedString(@"Custom", nil);
             cell.detailTextLabel.text = nil;
             if ([[defaults stringForKey:@"AudioQualityKind"] isEqualToString:@"custom"]) {
-                cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+                cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
                 cell.textLabel.textColor = [MUColor selectedTextColor];
             }
         }
@@ -135,7 +135,7 @@
         cell.textLabel.textColor = [UIColor blackColor];
     }
     cell = [self.tableView cellForRowAtIndexPath:indexPath];
-    cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+    cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
     cell.textLabel.textColor = [MUColor selectedTextColor];
     NSString *val = nil;
     switch ([indexPath row]) {

--- a/Source/Classes/MUAudioSidetonePreferencesViewController.m
+++ b/Source/Classes/MUAudioSidetonePreferencesViewController.m
@@ -61,7 +61,7 @@
     static NSString *CellIdentifier = @"MUAudioSidetonePreferencesCell";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:CellIdentifier] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:CellIdentifier];
     }
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
@@ -78,7 +78,6 @@
             [sidetoneSwitch addTarget:self action:@selector(sidetoneStatusChanged:) forControlEvents:UIControlEventValueChanged];
             [sidetoneSwitch setOn:[defaults boolForKey:@"AudioSidetone"]];
             cell.accessoryView = sidetoneSwitch;
-            [sidetoneSwitch release];
         } else if ([indexPath row] == 1) {
             NSLog(@"reloadin' (enabled? %u)", [defaults boolForKey:@"AudioSidetone"]);
             cell.textLabel.text = NSLocalizedString(@"Playback Volume", nil);
@@ -90,7 +89,6 @@
             [sidetoneSlider setValue:[defaults floatForKey:@"AudioSidetoneVolume"]];
             [sidetoneSlider setMinimumTrackTintColor:[UIColor blackColor]];
             cell.accessoryView = sidetoneSlider;
-            [sidetoneSlider release];
         }
     }
     

--- a/Source/Classes/MUAudioTransmissionPreferencesViewController.m
+++ b/Source/Classes/MUAudioTransmissionPreferencesViewController.m
@@ -97,7 +97,7 @@
     static NSString *CellIdentifier = @"AudioXmitOptionCell";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
     }
     
     NSString *current = [[NSUserDefaults standardUserDefaults] stringForKey:@"AudioTransmitMethod"];
@@ -109,19 +109,19 @@
         if (indexPath.row == 0) {
             cell.textLabel.text = NSLocalizedString(@"Voice Activated", nil);
             if ([current isEqualToString:@"vad"]) {
-                cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+                cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
                 cell.textLabel.textColor = [MUColor selectedTextColor];
             }
         } else if (indexPath.row == 1) {
             cell.textLabel.text = NSLocalizedString(@"Push-to-talk", nil);
             if ([current isEqualToString:@"ptt"]) {
-                cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+                cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
                 cell.textLabel.textColor = [MUColor selectedTextColor];
             }
         } else if (indexPath.row == 2) {
             cell.textLabel.text = NSLocalizedString(@"Continuous", nil);
             if ([current isEqualToString:@"continuous"]) {
-                cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+                cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
                 cell.textLabel.textColor = [MUColor selectedTextColor];
             }
         }
@@ -130,9 +130,9 @@
             if ([current isEqualToString:@"ptt"]) {
                 UITableViewCell *pttCell = [tableView dequeueReusableCellWithIdentifier:@"AudioXmitPTTCell"];
                 if (pttCell == nil) {
-                    pttCell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"AudioXmitPTTCell"] autorelease];
+                    pttCell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"AudioXmitPTTCell"];
                 }
-                UIImageView *mouthView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"talkbutton_off"]] autorelease];
+                UIImageView *mouthView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"talkbutton_off"]];
                 [mouthView setContentMode:UIViewContentModeCenter];
                 [mouthView setOpaque:NO];
                 [pttCell setBackgroundView:mouthView];
@@ -159,7 +159,7 @@
     if (section == 0) {
         return [MUTableViewHeaderLabel labelWithText:NSLocalizedString(@"Transmission Method", nil)];
     } else if (section == 1) {
-        UIView *parentView = [[[UIView alloc] initWithFrame:CGRectZero] autorelease];
+        UIView *parentView = [[UIView alloc] initWithFrame:CGRectZero];
         MUTableViewHeaderLabel *lbl = [MUTableViewHeaderLabel labelWithText:nil];
         lbl.font = [UIFont systemFontOfSize:16.0f];
         lbl.lineBreakMode = UILineBreakModeWordWrap;
@@ -247,14 +247,13 @@
         [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:1] withRowAnimation:UITableViewRowAnimationFade];
         
         cell = [self.tableView cellForRowAtIndexPath:indexPath];
-        cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+        cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
         cell.textLabel.textColor = [MUColor selectedTextColor];
     } else if (indexPath.section == 1) {
         if (indexPath.row == 0) {
             if ([current isEqualToString:@"vad"]) {
                 MUVoiceActivitySetupViewController *vadSetup = [[MUVoiceActivitySetupViewController alloc] init];
                 [self.navigationController pushViewController:vadSetup animated:YES];
-                [vadSetup release];
             }
         }	
     }

--- a/Source/Classes/MUBackgroundView.m
+++ b/Source/Classes/MUBackgroundView.m
@@ -11,12 +11,12 @@
 
 + (UIView *) backgroundView {
     if (MUGetOperatingSystemVersion() >= MUMBLE_OS_IOS_7) {
-        UIView *view = [[[UIView alloc] init] autorelease];
+        UIView *view = [[UIView alloc] init];
         [view setBackgroundColor:[MUColor backgroundViewiOS7Color]];
         return view;
     }
     
-    return [[[UIImageView alloc] initWithImage:[MUImage imageNamed:@"BackgroundTextureBlackGradient"]] autorelease];
+    return [[UIImageView alloc] initWithImage:[MUImage imageNamed:@"BackgroundTextureBlackGradient"]];
 }
 
 @end

--- a/Source/Classes/MUCertificateCreationProgressView.h
+++ b/Source/Classes/MUCertificateCreationProgressView.h
@@ -4,5 +4,4 @@
 
 @interface MUCertificateCreationProgressView : UIViewController
 - (id) initWithName:(NSString *)name email:(NSString *)email;
-- (void) dealloc;
 @end

--- a/Source/Classes/MUCertificateCreationProgressView.m
+++ b/Source/Classes/MUCertificateCreationProgressView.m
@@ -25,20 +25,14 @@
 
 - (id) initWithName:(NSString *)name email:(NSString *)email {
     if (self = [super initWithNibName:@"MUCertificateCreationProgressView" bundle:nil]) {
-        _identityName = [name retain];
-        _emailAddress = [email retain];
+        _identityName = name;
+        _emailAddress = email;
         
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
             [self.view setBackgroundColor:[UIColor groupTableViewBackgroundColor]];
         }
     }
     return self;
-}
-
-- (void) dealloc {
-    [_identityName release];
-    [_emailAddress release];
-    [super dealloc];
 }
 
 - (void) viewDidLoad {

--- a/Source/Classes/MUCertificateDiskImportViewController.h
+++ b/Source/Classes/MUCertificateDiskImportViewController.h
@@ -5,6 +5,5 @@
 @interface MUCertificateDiskImportViewController : UITableViewController <UIAlertViewDelegate, UITextFieldDelegate>
 
 - (id) init;
-- (void) dealloc;
 
 @end

--- a/Source/Classes/MUCertificateDiskImportViewController.m
+++ b/Source/Classes/MUCertificateDiskImportViewController.m
@@ -65,12 +65,6 @@ static void ShowAlertDialog(NSString *title, NSString *msg) {
     return self;
 }
 
-- (void) dealloc {
-    [_diskCertificates release];
-    [_attemptIndexPath release];
-    [super dealloc];
-}
-
 #pragma mark - View lifecycle
 
 - (void) viewWillAppear:(BOOL)animated {

--- a/Source/Classes/MUCertificateViewController.h
+++ b/Source/Classes/MUCertificateViewController.h
@@ -9,7 +9,6 @@
 - (id) initWithPersistentRef:(NSData *)persistentRef;
 - (id) initWithCertificate:(MKCertificate *)cert;
 - (id) initWithCertificates:(NSArray *)certs;
-- (void) dealloc;
 
 - (void) showDataForCertificate:(MKCertificate *)cert;
 - (void) updateCertificateDisplay;

--- a/Source/Classes/MUConnectionController.m
+++ b/Source/Classes/MUConnectionController.m
@@ -63,22 +63,16 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
     return self;
 }
 
-- (void) dealloc {
-    [_transitioningDelegate release];
-
-    [super dealloc];
-}
-
 - (void) connetToHostname:(NSString *)hostName port:(NSUInteger)port withUsername:(NSString *)userName andPassword:(NSString *)password withParentViewController:(UIViewController *)parentViewController {
-    _hostname = [hostName retain];
+    _hostname = hostName;
     _port = port;
-    _username = [userName retain];
-    _password = [password retain];
+    _username = userName;
+    _password = password;
     
     [self showConnectingView];
     [self establishConnection];
     
-    _parentViewController = [parentViewController retain];
+    _parentViewController = parentViewController;
 }
 
 - (BOOL) isConnected {
@@ -107,7 +101,6 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
 
 - (void) hideConnectingView {
     [_alertView dismissWithClickedButtonIndex:1 animated:YES];
-    [_alertView release];
     _alertView = nil;
     [_timer invalidate];
     _timer = nil;
@@ -143,14 +136,11 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
 
 - (void) teardownConnection {
     [_serverModel removeDelegate:self];
-    [_serverModel release];
     _serverModel = nil;
     [_connection setDelegate:nil];
     [_connection disconnect];
-    [_connection release]; 
     _connection = nil;
     [_timer invalidate];
-    [_serverRoot release];
     _serverRoot = nil;
     
     // Reset app badge. The connection is no more.
@@ -190,7 +180,6 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
                                                   cancelButtonTitle:NSLocalizedString(@"OK", nil)
                                                   otherButtonTitles:nil];
         [alertView show];
-        [alertView release];
         [self teardownConnection];
     }
 }
@@ -221,7 +210,6 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
                                               cancelButtonTitle:NSLocalizedString(@"OK", nil)
                                               otherButtonTitles:nil];
     [alertView show];
-    [alertView release];
     [self teardownConnection];
 }
 
@@ -252,7 +240,6 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
             [alert addButtonWithTitle:NSLocalizedString(@"Trust New Certificate", nil)];
             [alert addButtonWithTitle:NSLocalizedString(@"Show Certificates", nil)];
             [alert show];
-            [alert release];
         }
     } else {
         // No certhash of this certificate in the database for this hostname-port combo.  Let the user decide
@@ -269,7 +256,6 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
         [alert addButtonWithTitle:NSLocalizedString(@"Trust Certificate", nil)];
         [alert addButtonWithTitle:NSLocalizedString(@"Show Certificates", nil)];
         [alert show];
-        [alert release];
     }
 }
 
@@ -362,7 +348,6 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
     _rejectReason = reason;
 
     [alert show];
-    [alert release];
 }
 
 #pragma mark - MKServerModelDelegate
@@ -374,11 +359,8 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
 
     [_serverRoot takeOwnershipOfConnectionDelegate];
 
-    [_username release];
     _username = nil;
-    [_hostname release];
     _hostname = nil;
-    [_password release];
     _password = nil;
 
     if ([[UIDevice currentDevice] userInterfaceIdiom] != UIUserInterfaceIdiomPad) {
@@ -390,14 +372,13 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
     }
 
     [_parentViewController presentModalViewController:_serverRoot animated:YES];
-    [_parentViewController release];
     _parentViewController = nil;
 }
 
 #pragma mark - UIAlertView delegate
 
 - (void) alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
-    
+
     // Actions for the outermost UIAlertView
     if (alertView == _alertView) {
         if (buttonIndex == 0) {
@@ -407,15 +388,13 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
         }
         return;
     }
-    
+
     // Actions for the rejection UIAlertView
     if (alertView == _rejectAlertView) {
         if (_rejectReason == MKRejectReasonInvalidUsername || _rejectReason == MKRejectReasonUsernameInUse) {
-            [_username release];
             UITextField *textField = [_rejectAlertView textFieldAtIndex:0];
             _username = [[textField text] copy];
         } else if (_rejectReason == MKRejectReasonWrongServerPassword || _rejectReason == MKRejectReasonWrongUserPassword) {
-            [_password release];
             UITextField *textField = [_rejectAlertView textFieldAtIndex:0];
             _password = [[textField text] copy];
         }
@@ -428,14 +407,14 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
         }
         return;
     }
-    
+
     // Actions that follow are for the certificate trust alert view
-    
+
     // Cancel
     if (buttonIndex == 0) {
         // Tear down the connection.
         [self teardownConnection];
-        
+
     // Ignore
     } else if (buttonIndex == 1) {
         // Ignore just reconnects to the server without
@@ -444,7 +423,7 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
         [_connection setIgnoreSSLVerification:YES];
         [_connection reconnect];
         [self showConnectingView];
-        
+
     // Trust
     } else if (buttonIndex == 2) {
         // Store the cert hash of the leaf certificate.  We then ignore certificate
@@ -456,15 +435,13 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
         [_connection setIgnoreSSLVerification:YES];
         [_connection reconnect];
         [self showConnectingView];
-        
+
     // Show certificates
     } else if (buttonIndex == 3) {
         MUServerCertificateTrustViewController *certTrustView = [[MUServerCertificateTrustViewController alloc] initWithCertificates:[_connection peerCertificates]];
         [certTrustView setDelegate:self];
         UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:certTrustView];
-        [certTrustView release];
         [_parentViewController presentModalViewController:navCtrl animated:YES];
-        [navCtrl release];
     }
 }
 

--- a/Source/Classes/MUCountryServerListController.h
+++ b/Source/Classes/MUCountryServerListController.h
@@ -4,6 +4,5 @@
 
 @interface MUCountryServerListController : UIViewController 
 - (id) initWithName:(NSString *)country serverList:(NSArray *)servers;
-- (void) dealloc;
 - (void) presentAddAsFavouriteDialogForServer:(NSDictionary *)serverItem;
 @end

--- a/Source/Classes/MUCountryServerListController.m
+++ b/Source/Classes/MUCountryServerListController.m
@@ -29,19 +29,11 @@
     if (self == nil)
         return nil;
     
-    _countryServers = [servers retain];
+    _countryServers = servers;
     _visibleServers = [servers mutableCopy];
-    _countryName = [[country copy] retain];
+    _countryName = [country copy];
     
     return self;
-}
-
-- (void) dealloc {
-    [_countryName release];
-    [_countryServers release];
-    [_visibleServers release];
-    
-    [super dealloc];
 }
 
 - (UITableView *) tableView {
@@ -54,7 +46,6 @@
     [_tableView setDelegate:self];
     [_tableView setAutoresizingMask:UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth];
     [self.view addSubview:_tableView];
-    [_tableView release];
     
     [self resetSearch];
 }
@@ -81,7 +72,6 @@
 
     UIBarButtonItem *searchButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemSearch target:self action:@selector(searchButtonClicked:)];
     self.navigationItem.rightBarButtonItem = searchButton;
-    [searchButton release];
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
@@ -118,7 +108,7 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     MUServerCell *cell = (MUServerCell *) [tableView dequeueReusableCellWithIdentifier:[MUServerCell reuseIdentifier]];
     if (cell == nil) {
-        cell = [[[MUServerCell alloc] init] autorelease];
+        cell = [[MUServerCell alloc] init];
     }
     
     NSDictionary *serverItem = [_visibleServers objectAtIndex:[indexPath row]];
@@ -144,7 +134,6 @@
                                                                 NSLocalizedString(@"Connect", nil), nil];
     [sheet setActionSheetStyle:UIActionSheetStyleBlackOpaque];
     [sheet showInView:[self tableView]];
-    [sheet release];
 }
 
 - (void) actionSheet:(UIActionSheet *)sheet clickedButtonAtIndex:(NSInteger)index {
@@ -163,7 +152,6 @@
         [alert setAlertViewStyle:UIAlertViewStylePlainTextInput];
         [[alert textFieldAtIndex:0] setText:[MUDatabase usernameForServerWithHostname:[serverItem objectForKey:@"ip"] port:[[serverItem objectForKey:@"port"] intValue]]];
         [alert show];
-        [alert release];
 
     // Add as favourite
     } else if (index == 0) {
@@ -187,25 +175,19 @@
     [editView setTarget:self];
     [editView setDoneAction:@selector(doneButtonClicked:)];
     [modalNav pushViewController:editView animated:NO];
-    [editView release];
 
     [[self navigationController] presentModalViewController:modalNav animated:YES];
-
-    [modalNav release];
-    [favServ release];
 }
 
 - (void) doneButtonClicked:(id)sender {
     MUFavouriteServerEditViewController *editView = (MUFavouriteServerEditViewController *)sender;
     MUFavouriteServer *favServ = [editView copyFavouriteFromContent];
     [MUDatabase storeFavourite:favServ];
-    [favServ release];
 
     MUFavouriteServerListController *favController = [[MUFavouriteServerListController alloc] init];
     UINavigationController *navCtrl = [self navigationController];
     [navCtrl popToRootViewControllerAnimated:NO];
     [navCtrl pushViewController:favController animated:YES];
-    [favController release];
 }
 
 - (void) alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
@@ -228,8 +210,7 @@
 #pragma mark SearchBar methods
 
 - (void) resetSearch {
-    [_visibleServers release];
-    _visibleServers = [_countryServers retain];
+    _visibleServers = _countryServers;
 }
 
 - (void) performSearchForTerm:(NSString *)searchTerm {        
@@ -242,7 +223,6 @@
             }
         }
         dispatch_async(dispatch_get_main_queue(), ^{
-            [_visibleServers release];
             _visibleServers = results;
             [self.tableView reloadData]; 
         });
@@ -321,14 +301,12 @@
     
     UIBarButtonItem *cancelSearchButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelSearchButtonClicked:)];
     self.navigationItem.rightBarButtonItem = cancelSearchButton;
-    [cancelSearchButton release];
     
     UISearchBar *searchBar = [[UISearchBar alloc] initWithFrame:CGRectZero];
     searchBar.delegate = self;
     searchBar.barStyle = UIBarStyleBlack;
     [searchBar sizeToFit];
     self.navigationItem.titleView = searchBar;
-    [searchBar release];
 
     [searchBar becomeFirstResponder];
 }
@@ -339,7 +317,6 @@
     
     UIBarButtonItem *searchButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemSearch target:self action:@selector(searchButtonClicked:)];
     self.navigationItem.rightBarButtonItem = searchButton;
-    [searchButton release];
     
     self.navigationItem.hidesBackButton = NO;
     self.navigationItem.titleView = nil;

--- a/Source/Classes/MUDatabase.m
+++ b/Source/Classes/MUDatabase.m
@@ -71,7 +71,6 @@ static FMDatabase *db = nil;
         NSLog(@"MUDatabase: Initialized database at %@", dbPath);
     } else {
         NSLog(@"MUDatabase: Could not open database at %@", dbPath);
-        [db release];
         db = nil;
         return;
     }
@@ -114,7 +113,7 @@ static FMDatabase *db = nil;
 
 // Tear down the database
 + (void) teardown {
-    [db release];
+    
 }
 
 // Store a single favourite
@@ -178,10 +177,9 @@ static FMDatabase *db = nil;
         [fs setUserName:[res stringForColumnIndex:4]];
         [fs setPassword:[res stringForColumnIndex:5]];
         [favs addObject:fs];
-        [fs release];
     }
     [res close];
-    return [favs autorelease];
+    return favs;
 }
 
 #pragma mark -

--- a/Source/Classes/MUFavouriteServer.h
+++ b/Source/Classes/MUFavouriteServer.h
@@ -6,7 +6,6 @@
 
 - (id) initWithDisplayName:(NSString *)displayName hostName:(NSString *)hostName port:(NSUInteger)port userName:(NSString *)userName password:(NSString *)passWord;
 - (id) init;
-- (void) dealloc;
 
 @property (assign)  NSInteger   primaryKey;
 @property (copy)    NSString    *displayName;

--- a/Source/Classes/MUFavouriteServer.m
+++ b/Source/Classes/MUFavouriteServer.m
@@ -43,14 +43,6 @@
     return [self initWithDisplayName:nil hostName:nil port:0 userName:nil password:nil];
 }
 
-- (void) dealloc {
-    [_displayName release];
-    [_hostName release];
-    [_userName release];
-    [_password release];
-    [super dealloc];
-}
-
 - (id) copyWithZone:(NSZone *)zone {
     MUFavouriteServer *favServ = [[MUFavouriteServer alloc] initWithDisplayName:_displayName hostName:_hostName port:_port userName:_userName password:_password];
     if ([self hasPrimaryKey])

--- a/Source/Classes/MUFavouriteServerEditViewController.h
+++ b/Source/Classes/MUFavouriteServerEditViewController.h
@@ -7,7 +7,6 @@
 @interface MUFavouriteServerEditViewController : UITableViewController 
 - (id) initInEditMode:(BOOL)editMode withContentOfFavouriteServer:(MUFavouriteServer *)favServ;
 - (id) init;
-- (void) dealloc;
 
 #pragma mark Accessors
 

--- a/Source/Classes/MUFavouriteServerEditViewController.m
+++ b/Source/Classes/MUFavouriteServerEditViewController.m
@@ -178,23 +178,6 @@
     return [self initInEditMode:NO withContentOfFavouriteServer:nil];
 }
 
-- (void) dealloc {
-    [_favourite release];
-
-    [_descriptionCell release];
-    [_descriptionField release];
-    [_addressCell release];
-    [_addressField release];
-    [_portCell release];
-    [_portField release];
-    [_usernameCell release];
-    [_usernameField release];
-    [_passwordCell release];
-    [_passwordField release];
-
-    [super dealloc];
-}
-
 - (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
     // On iPad, we support all interface orientations.
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
@@ -247,7 +230,6 @@
                                                                     target:self
                                                                     action:@selector(cancelClicked:)];
     [[self navigationItem] setLeftBarButtonItem:cancelButton];
-    [cancelButton release];
 
     // Done
     UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Done", nil)
@@ -255,7 +237,6 @@
                                                                   target:self
                                                                   action:@selector(doneClicked:)];
     [[self navigationItem] setRightBarButtonItem:doneButton];
-    [doneButton release];
 }
 
 - (void) viewWillDisappear:(BOOL)animated {

--- a/Source/Classes/MUFavouriteServerListController.h
+++ b/Source/Classes/MUFavouriteServerListController.h
@@ -6,7 +6,6 @@
 
 @interface MUFavouriteServerListController : UITableViewController <UIActionSheetDelegate>
 - (id) init;
-- (void) dealloc;
 - (void) presentNewFavouriteDialog;
 - (void) presentEditDialogForFavourite:(MUFavouriteServer *)favServ;
 @end

--- a/Source/Classes/MUFavouriteServerListController.m
+++ b/Source/Classes/MUFavouriteServerListController.m
@@ -37,9 +37,6 @@
 
 - (void) dealloc {
     [MUDatabase storeFavourites:_favouriteServers];
-    [_favouriteServers release];
-    
-    [super dealloc];
 }
 
 - (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation {
@@ -71,14 +68,12 @@
     
     UIBarButtonItem *addButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd target:self action:@selector(addButtonClicked:)];
     [[self navigationItem] setRightBarButtonItem:addButton];
-    [addButton release];
 
     [self reloadFavourites];
 }
 
 - (void) reloadFavourites {
-    [_favouriteServers release];
-    _favouriteServers = [[MUDatabase fetchAllFavourites] retain];
+    _favouriteServers = [MUDatabase fetchAllFavourites];
     [_favouriteServers sortUsingSelector:@selector(compare:)];
 }
 
@@ -97,7 +92,7 @@
     MUFavouriteServer *favServ = [_favouriteServers objectAtIndex:[indexPath row]];
     MUServerCell *cell = (MUServerCell *)[tableView dequeueReusableCellWithIdentifier:[MUServerCell reuseIdentifier]];
     if (cell == nil) {
-        cell = [[[MUServerCell alloc] init] autorelease];
+        cell = [[MUServerCell alloc] init];
     }
     [cell populateFromFavouriteServer:favServ];
     cell.selectionStyle = UITableViewCellSelectionStyleGray;
@@ -136,7 +131,6 @@
     } else {
         [sheet showInView:cellView];
     }
-    [sheet release];
 }
 
 - (void) deleteFavouriteAtIndexPath:(NSIndexPath *)indexPath {
@@ -165,7 +159,6 @@
                                                   cancelButtonTitle:NSLocalizedString(@"No", nil)
                                                   otherButtonTitles:NSLocalizedString(@"Yes", nil), nil];
         [alertView show];
-        [alertView release];
     // Connect
     } else if (index == 2) {
         NSString *userName = [favServ userName];
@@ -217,11 +210,9 @@
     [editView setTarget:self];
     [editView setDoneAction:@selector(doneButtonClicked:)];
     [modalNav pushViewController:editView animated:NO];
-    [editView release];
     
     modalNav.modalPresentationStyle = UIModalPresentationFormSheet;
     [[self navigationController] presentModalViewController:modalNav animated:YES];
-    [modalNav release];
 }
 
 - (void) presentEditDialogForFavourite:(MUFavouriteServer *)favServ {
@@ -235,11 +226,9 @@
     [editView setTarget:self];
     [editView setDoneAction:@selector(doneButtonClicked:)];
     [modalNav pushViewController:editView animated:NO];
-    [editView release];
     
     modalNav.modalPresentationStyle = UIModalPresentationFormSheet;
     [[self navigationController] presentModalViewController:modalNav animated:YES];
-    [modalNav release];
 }
 
 #pragma mark -
@@ -260,7 +249,6 @@
     MUFavouriteServerEditViewController *editView = sender;
     MUFavouriteServer *newServer = [editView copyFavouriteFromContent];
     [MUDatabase storeFavourite:newServer];
-    [newServer release];
 
     [self reloadFavourites];
     [self.tableView reloadData];

--- a/Source/Classes/MUImageViewController.m
+++ b/Source/Classes/MUImageViewController.m
@@ -18,15 +18,10 @@
 
 - (id) initWithImages:(NSArray *)images {
     if ((self = [super init])) {
-        _images = [images retain];
+        _images = images;
         _curPage = 0;
     }
     return self;
-}
-
-- (void) dealloc {
-    [_images release];
-    [super dealloc];
 }
 
 - (void) viewDidLoad {
@@ -61,20 +56,12 @@
         [imgZoomer setShowsHorizontalScrollIndicator:NO];
         [_scrollView addSubview:imgZoomer];
         [imageViews addObject:imgView];
-        [imgView release];
-        [imgZoomer release];
         ++i;
     }
 
     _imageViews = imageViews;
     
     [self.view addSubview:_scrollView];
-}
-
-- (void) viewDidUnload {
-    [super viewDidUnload];
-    [_scrollView release];
-    [_imageViews release];
 }
 
 - (void) viewWillAppear:(BOOL)animated {
@@ -96,7 +83,6 @@
     
     UIBarButtonItem *actionButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(actionClicked:)];
     self.navigationItem.rightBarButtonItem = actionButton;
-    [actionButton release];
 }
 
 - (BOOL) shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
@@ -141,7 +127,6 @@
                                                    cancelButtonTitle:NSLocalizedString(@"OK", nil)
                                                   otherButtonTitles:nil];
         [alertView show];
-        [alertView release];
     }
 }
 
@@ -153,7 +138,6 @@
                                                     otherButtonTitles:NSLocalizedString(@"Export to Photos", nil), nil];
     [actionSheet setActionSheetStyle:UIActionSheetStyleBlackOpaque];
     [actionSheet showFromBarButtonItem:sender animated:YES];
-    [actionSheet release];
 }
 
 @end

--- a/Source/Classes/MULanServerListController.h
+++ b/Source/Classes/MULanServerListController.h
@@ -6,5 +6,4 @@
 
 @interface MULanServerListController : UITableViewController
 - (id) init;
-- (void) dealloc;
 @end

--- a/Source/Classes/MULanServerListController.m
+++ b/Source/Classes/MULanServerListController.m
@@ -44,12 +44,6 @@ static NSInteger NetServiceAlphabeticalSort(id arg1, id arg2, void *reverse) {
     return self;
 }
 
-- (void) dealloc {
-    [_browser release];
-    [_netServices release];
-    [super dealloc];
-}
-
 #pragma mark -
 
 - (void) viewWillAppear:(BOOL)animated {
@@ -122,7 +116,7 @@ static NSInteger NetServiceAlphabeticalSort(id arg1, id arg2, void *reverse) {
     NSNetService *netService = [_netServices objectAtIndex:[indexPath row]];
     MUServerCell *cell = (MUServerCell *)[tableView dequeueReusableCellWithIdentifier:[MUServerCell reuseIdentifier]];
     if (cell == nil) {
-        cell = [[[MUServerCell alloc] init] autorelease];
+        cell = [[MUServerCell alloc] init];
     }
     [cell populateFromDisplayName:[netService name] hostName:[netService hostName] port:[NSString stringWithFormat:@"%li", (long)[netService port]]];
     cell.selectionStyle = UITableViewCellSelectionStyleGray;
@@ -148,7 +142,6 @@ static NSInteger NetServiceAlphabeticalSort(id arg1, id arg2, void *reverse) {
                                                                 NSLocalizedString(@"Connect", nil), nil];
     [sheet setActionSheetStyle:UIActionSheetStyleBlackOpaque];
     [sheet showInView:[self tableView]];
-    [sheet release];
 }
 
 - (void) actionSheet:(UIActionSheet *)sheet clickedButtonAtIndex:(NSInteger)index {
@@ -167,7 +160,6 @@ static NSInteger NetServiceAlphabeticalSort(id arg1, id arg2, void *reverse) {
         [alert setAlertViewStyle:UIAlertViewStylePlainTextInput];
         [[alert textFieldAtIndex:0] setText:[MUDatabase usernameForServerWithHostname:[netService hostName] port:[netService port]]];
         [alert show];
-        [alert release];
 
     // Add as favourite
     } else if (index == 0) {
@@ -191,25 +183,19 @@ static NSInteger NetServiceAlphabeticalSort(id arg1, id arg2, void *reverse) {
     [editView setTarget:self];
     [editView setDoneAction:@selector(doneButtonClicked:)];
     [modalNav pushViewController:editView animated:NO];
-    [editView release];
     
     [[self navigationController] presentModalViewController:modalNav animated:YES];
-    
-    [modalNav release];
-    [favServ release];
 }
 
 - (void) doneButtonClicked:(id)sender {
     MUFavouriteServerEditViewController *editView = (MUFavouriteServerEditViewController *)sender;
     MUFavouriteServer *favServ = [editView copyFavouriteFromContent];
     [MUDatabase storeFavourite:favServ];
-    [favServ release];
     
     MUFavouriteServerListController *favController = [[MUFavouriteServerListController alloc] init];
     UINavigationController *navCtrl = [self navigationController];
     [navCtrl popToRootViewControllerAnimated:NO];
     [navCtrl pushViewController:favController animated:YES];
-    [favController release];
 }
 
 - (void) alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {

--- a/Source/Classes/MULegalViewController.m
+++ b/Source/Classes/MULegalViewController.m
@@ -39,7 +39,6 @@
     
     UIBarButtonItem *done = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneButtonClicked:)];
     self.navigationItem.rightBarButtonItem = done;
-    [done release];
 
     NSData *html = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"Legal" ofType:@"html"]];
     [_webView loadData:html MIMEType:@"text/html" textEncodingName:@"utf-8" baseURL:nil];

--- a/Source/Classes/MUMessageAttachmentViewController.m
+++ b/Source/Classes/MUMessageAttachmentViewController.m
@@ -19,8 +19,8 @@
 
 - (id) initWithImages:(NSArray *)images andLinks:(NSArray *)links {
     if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
-        _images = [images retain];
-        _links = [links retain];
+        _images = images;
+        _links = links;
     }
     return self;
 }
@@ -94,7 +94,7 @@
     static NSString *CellIdentifier = @"Cell";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:CellIdentifier] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:CellIdentifier];
     }
     
     cell.selectionStyle = UITableViewCellSelectionStyleGray;
@@ -128,7 +128,6 @@
     if (hasImages && [indexPath section] == 0) {
         MUImageViewController *imgViewController = [[MUImageViewController alloc] initWithImages:_images];
         [self.navigationController pushViewController:imgViewController animated:YES];
-        [imgViewController release];
     } else {
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[_links objectAtIndex:[indexPath row]]]];
     }

--- a/Source/Classes/MUMessageBubbleTableViewCell.m
+++ b/Source/Classes/MUMessageBubbleTableViewCell.m
@@ -59,14 +59,6 @@
     return self;
 }
 
-- (void) dealloc {
-    [_shownImages release];
-    [_message release];
-    [_heading release];
-    [_date release];
-    [super dealloc];
-}
-
 + (CGSize) textSizeForText:(NSString *)text {
     CGSize constraintSize = CGSizeMake(kBalloonWidth-(kBalloonMarginTailSide+kBalloonMarginNonTailSide), CGFLOAT_MAX);
     return [text sizeWithFont:[UIFont systemFontOfSize:14.0f] constrainedToSize:constraintSize lineBreakMode:UILineBreakModeWordWrap];
@@ -90,13 +82,13 @@
 }
 
 + (NSString *) stringForDate:(NSDate *)date {
-    NSDateFormatter *fmt = [[[NSDateFormatter alloc] init] autorelease];
+    NSDateFormatter *fmt = [[NSDateFormatter alloc] init];
     [fmt setDateFormat:@"HH:mm"];
     return [fmt stringFromDate:date];
 }
 
 + (CGSize) imageSizeForImages:(NSArray *)images resizedToFitWithinSize:(CGSize)sz andNewImageSizes:(NSArray **)array {
-    NSMutableArray *imageSizes = [[[NSMutableArray alloc] initWithCapacity:[images count]] autorelease];
+    NSMutableArray *imageSizes = [[NSMutableArray alloc] initWithCapacity:[images count]];
     CGFloat imagesHeight = 0;
     for (UIImage *image in images) {
         CGSize imgSize = [image size];
@@ -259,25 +251,21 @@
 }
 
 - (void) setHeading:(NSString *)heading {
-    [_heading release];
     _heading = [heading copy];
     [self setNeedsDisplay];
 }
 
 - (void) setFooter:(NSString *)footer {
-    [_footer release];
     _footer = [footer copy];
     [self setNeedsDisplay];
 }
 
 - (void) setMessage:(NSString *)msg {
-    [_message release];
     _message = [msg copy];
     [self setNeedsDisplay];
 }
 
 - (void) setDate:(NSDate *)date {
-    [_date release];
     _date = [date copy];
     [self setNeedsDisplay];
 }
@@ -293,7 +281,7 @@
 }
 
 - (void) setShownImages:(NSArray *)shownImages {
-    _shownImages = [shownImages retain];
+    _shownImages = shownImages;
     [self setNeedsDisplay];
 }
 
@@ -353,19 +341,11 @@
         
         _longPressRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(showMenu:)];
         [_bubbleView addGestureRecognizer:_longPressRecognizer];
-        [_longPressRecognizer release];
         
         _tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(showAttachments:)];
         [_bubbleView addGestureRecognizer:_tapRecognizer];
-        [_tapRecognizer release];
     }
     return self;
-}
-
-- (void) dealloc {
-    [_bubbleView release];
-    [_longPressRecognizer release];
-    [super dealloc];
 }
 
 - (void) setDelegate:(id<MUMessageBubbleTableViewCellDelegate>)delegate {

--- a/Source/Classes/MUMessageRecipientViewController.m
+++ b/Source/Classes/MUMessageRecipientViewController.m
@@ -24,7 +24,7 @@
 
 - (id) initWithServerModel:(MKServerModel *)model {
     if ((self = [super initWithStyle:UITableViewStylePlain])) {
-        _serverModel = [model retain];
+        _serverModel = model;
         [_serverModel addDelegate:self];
     }
     return self;
@@ -32,7 +32,6 @@
 
 - (void) dealloc {
     [_serverModel removeDelegate:self];
-    [super dealloc];
 }
 
 - (id<MUMessageRecipientViewControllerDelegate>) delegate {
@@ -44,13 +43,10 @@
 }
 
 - (void) rebuildModelArrayFromChannel:(MKChannel *)channel {
-    [_modelItems release];
     _modelItems = [[NSMutableArray alloc] init];
-    
-    [_userIndexMap release];
+
     _userIndexMap = [[NSMutableDictionary alloc] init];
-    
-    [_channelIndexMap release];
+
     _channelIndexMap = [[NSMutableDictionary alloc] init];
     
     [self addChannelTreeToModel:channel indentLevel:0];
@@ -113,7 +109,7 @@
         self.tableView.separatorInset = UIEdgeInsetsZero;
     }
 
-    self.navigationItem.leftBarButtonItem = [[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelClicked:)] autorelease];
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelClicked:)];
     
     [self rebuildModelArrayFromChannel:[_serverModel rootChannel]];
     [self.tableView reloadData];
@@ -163,9 +159,9 @@
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
         if (MUGetOperatingSystemVersion() >= MUMBLE_OS_IOS_7) {
-            cell = [[[MUServerTableViewCell alloc] initWithReuseIdentifier:CellIdentifier] autorelease];
+            cell = [[MUServerTableViewCell alloc] initWithReuseIdentifier:CellIdentifier];
         } else {
-            cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier] autorelease];
+            cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
         }
     }
 

--- a/Source/Classes/MUMessagesDatabase.m
+++ b/Source/Classes/MUMessagesDatabase.m
@@ -41,17 +41,11 @@
     return self;
 }
 
-- (void) dealloc {
-    [_msgCache release];
-    [_db release];
-    [super dealloc];
-}
-
 - (void) addMessage:(MKTextMessage *)msg withHeading:(NSString *)heading andSentBySelf:(BOOL)selfSent {
     NSError *err = nil;
     NSString *plainMsg = [msg plainTextString];
     plainMsg = [plainMsg stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    NSMutableArray *imageDataArray = [[[NSMutableArray alloc] initWithCapacity:[[msg embeddedImages] count]] autorelease];
+    NSMutableArray *imageDataArray = [[NSMutableArray alloc] initWithCapacity:[[msg embeddedImages] count]];
     for (NSString *dataUrl in [msg embeddedImages]) {
         NSData *imgData = [MUDataURL dataFromDataURL:dataUrl];
         if (imgData) {
@@ -89,7 +83,7 @@
             NSDictionary *dict = [NSPropertyListSerialization propertyListWithData:plistData options:0 format:nil error:nil];
             if (dict) {
                 NSArray *imgDataArray = [dict objectForKey:@"images"];
-                NSMutableArray *imagesArray = [[[NSMutableArray alloc] initWithCapacity:[imgDataArray count]] autorelease];
+                NSMutableArray *imagesArray = [[NSMutableArray alloc] initWithCapacity:[imgDataArray count]];
                 for (NSData *data in imgDataArray) {
                     [imagesArray addObject:[UIImage imageWithData:data]];
                 }

--- a/Source/Classes/MUMessagesViewController.m
+++ b/Source/Classes/MUMessagesViewController.m
@@ -73,7 +73,7 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
     if ((self = [super initWithFrame:CGRectZero])) {
         [self setOpaque:NO];
         if ([str length] >= 15) {
-            _str = [[NSString stringWithFormat:@"%@...", [str substringToIndex:11]] retain];
+            _str = [NSString stringWithFormat:@"%@...", [str substringToIndex:11]];
         } else {
             _str = [str copy];
         }
@@ -152,7 +152,7 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
 
 - (id) initWithServerModel:(MKServerModel *)model {
     if ((self = [super init])) {
-        _model = [model retain];
+        _model = model;
         [_model addDelegate:self];
         _msgdb = [[MUMessagesDatabase alloc] init];
     }
@@ -160,16 +160,10 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
 }
 
 - (void) dealloc {
-    [_msgdb release];
     [_model removeDelegate:self];
-    [_model release];
-    [_textField release];
-    [_tableView release];
-    [super dealloc];
 }
 
 - (void) clearAllMessages {
-    [_msgdb release];
     _msgdb = [[MUMessagesDatabase alloc] init];
     [_tableView reloadData];
 }
@@ -192,12 +186,10 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
     UISwipeGestureRecognizer *swipeGesture = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(hideKeyboard:)];
     [swipeGesture setDirection:UISwipeGestureRecognizerDirectionDown];
     [self.view addGestureRecognizer:swipeGesture];
-    [swipeGesture release];
 
     swipeGesture = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(showKeyboard:)];
     [swipeGesture setDirection:UISwipeGestureRecognizerDirectionUp];
     [self.view addGestureRecognizer:swipeGesture];
-    [swipeGesture release];
 
     CGRect textBarFrame = CGRectMake(0, frame.size.height, frame.size.width, 44);
     _textBarView = [[UIView alloc] initWithFrame:textBarFrame];
@@ -210,7 +202,7 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
         _textBarView.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"BlackToolbarPattern"]];
     }
 
-    _textField = [[[MUConsistentTextField alloc] initWithFrame:CGRectMake(6, 6, frame.size.width-12, 44-12)] autorelease];
+    _textField = [[MUConsistentTextField alloc] initWithFrame:CGRectMake(6, 6, frame.size.width-12, 44-12)];
     _textField.leftViewMode = UITextFieldViewModeAlways;
     _textField.rightViewMode = UITextFieldViewModeAlways;
     _textField.borderStyle = UITextBorderStyleRoundedRect;
@@ -226,12 +218,12 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
 }
 
 - (void) setReceiverName:(NSString *)receiver andImage:(NSString *)imageName {
-    MUMessageReceiverButton *receiverView = [[[MUMessageReceiverButton alloc] initWithText:receiver] autorelease];
+    MUMessageReceiverButton *receiverView = [[MUMessageReceiverButton alloc] initWithText:receiver];
     [receiverView addTarget:self action:@selector(showRecipientPicker:) forControlEvents:UIControlEventTouchUpInside];
 
     if (MUGetOperatingSystemVersion() >= MUMBLE_OS_IOS_7) {
         CGRect paddedRect = CGRectMake(0, 0, CGRectGetWidth(receiverView.frame) + 12, CGRectGetHeight(receiverView.frame));
-        UIView *paddedView = [[[UIView alloc] initWithFrame:paddedRect] autorelease];
+        UIView *paddedView = [[UIView alloc] initWithFrame:paddedRect];
         [paddedView addSubview:receiverView];
         paddedRect.origin.x += 6;
         [receiverView setFrame:paddedRect];
@@ -240,7 +232,7 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
         _textField.leftView = receiverView;
     }
 
-    UIImageView *imgView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:imageName]] autorelease];
+    UIImageView *imgView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:imageName]];
     if (MUGetOperatingSystemVersion() >= MUMBLE_OS_IOS_7) {
         CGRect paddedFrame = CGRectMake(0, 0, CGRectGetWidth(imgView.frame) + 6, CGRectGetHeight(imgView.frame));
         UIView *paddedView = [[UIView alloc] initWithFrame:paddedFrame];
@@ -486,10 +478,8 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
     MUMessageRecipientViewController *recipientViewController = [[MUMessageRecipientViewController alloc] initWithServerModel:_model];
     [recipientViewController setDelegate:self];
     UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:recipientViewController];
-    [recipientViewController release];
 
     [self presentModalViewController:navCtrl animated:YES];
-    [navCtrl release];
 }
 
 #pragma mark - MUMessageBubbleTableViewCellDelegate
@@ -515,11 +505,9 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
         if ([[txtMsg embeddedLinks] count] > 0) {
             MUMessageAttachmentViewController *attachmentViewController = [[MUMessageAttachmentViewController alloc] initWithImages:[txtMsg embeddedImages] andLinks:[txtMsg embeddedLinks]];
             [self.navigationController pushViewController:attachmentViewController animated:YES];
-            [attachmentViewController release];
         } else {
             MUImageViewController *imgViewController = [[MUImageViewController alloc] initWithImages:[txtMsg embeddedImages]];
             [self.navigationController pushViewController:imgViewController animated:YES];
-            [imgViewController release];
         }
     }
 }
@@ -613,12 +601,11 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
    
     UIApplication *app = [UIApplication sharedApplication];
     if ([app applicationState] == UIApplicationStateBackground) {
-        UILocalNotification *notification = [[[UILocalNotification alloc] init] autorelease];
+        UILocalNotification *notification = [[UILocalNotification alloc] init];
         
         NSMutableCharacterSet *trimSet = [[NSMutableCharacterSet alloc] init];
         [trimSet formUnionWithCharacterSet:[NSCharacterSet whitespaceCharacterSet]];
         [trimSet formUnionWithCharacterSet:[NSCharacterSet newlineCharacterSet]];
-        [trimSet autorelease];
     
         NSString *msgText = [[msg plainTextString] stringByTrimmingCharactersInSet:trimSet];
         NSUInteger numImages = [[msg embeddedImages] count];

--- a/Source/Classes/MUNotificationController.m
+++ b/Source/Classes/MUNotificationController.m
@@ -35,9 +35,7 @@
 }
 
 - (void) dealloc {
-    [_notificationQueue release];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [super dealloc];
 }
 
 - (void) keyboardDidShow:(NSNotification *)notification {
@@ -52,7 +50,7 @@
 
 - (void) addNotification:(NSString *)text {
     if ([_notificationQueue count] < 10)
-        [_notificationQueue addObject:[[text copy] autorelease]];
+        [_notificationQueue addObject:[text copy]];
     if (!_running) {
         [self showNext];
     }
@@ -77,7 +75,6 @@
     bg.backgroundColor = [UIColor blackColor];
     bg.alpha = 0.8f;
     [container addSubview:bg];
-    [bg release];
 
     UILabel *lbl = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, width, height)];
     lbl.font = [UIFont systemFontOfSize:16.0f];
@@ -88,7 +85,6 @@
     lbl.backgroundColor = [UIColor clearColor];
     lbl.textAlignment = UITextAlignmentCenter;
     [container addSubview:lbl];
-    [lbl release];
     
     [[[UIApplication sharedApplication] keyWindow] addSubview:container];
 
@@ -106,7 +102,6 @@
         _notificationView.alpha = 0.0f;
     } completion:^(BOOL completed) {
         [_notificationView removeFromSuperview];
-        [_notificationView release];
         _notificationView = nil;
         if ([_notificationQueue count] > 0) {
             [self performSelectorOnMainThread:@selector(showNext) withObject:nil waitUntilDone:NO];

--- a/Source/Classes/MUPopoverBackgroundView.m
+++ b/Source/Classes/MUPopoverBackgroundView.m
@@ -23,11 +23,6 @@
     return self;
 }
 
-- (void) dealloc {
-    [_imgView release];
-    [super dealloc];
-}
-
 - (UIPopoverArrowDirection) arrowDirection {
     return UIPopoverArrowDirectionUp;
 }

--- a/Source/Classes/MUPreferencesViewController.h
+++ b/Source/Classes/MUPreferencesViewController.h
@@ -4,5 +4,4 @@
 
 @interface MUPreferencesViewController : UITableViewController
 - (id) init;
-- (void) dealloc;
 @end

--- a/Source/Classes/MUPreferencesViewController.m
+++ b/Source/Classes/MUPreferencesViewController.m
@@ -41,7 +41,6 @@
     [[NSUserDefaults standardUserDefaults] synchronize];
     MUApplicationDelegate *delegate = [[UIApplication sharedApplication] delegate];
     [delegate reloadPreferences];
-    [super dealloc];
 }
 
 #pragma mark -
@@ -117,7 +116,7 @@
     static NSString *CellIdentifier = @"PreferencesCell";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
     }
     cell.selectionStyle = UITableViewCellSelectionStyleGray;
     cell.accessoryType = UITableViewCellAccessoryNone;
@@ -135,13 +134,12 @@
             [cell setAccessoryView:volSlider];
             [cell setSelectionStyle:UITableViewCellSelectionStyleNone];
             [volSlider addTarget:self action:@selector(audioVolumeChanged:) forControlEvents:UIControlEventValueChanged];
-            [volSlider release];
         }
         // Transmit method
         if ([indexPath row] == 1) {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"AudioTransmitCell"];
             if (cell == nil)
-                cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"AudioTransmitCell"] autorelease];
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"AudioTransmitCell"];
             cell.textLabel.text = NSLocalizedString(@"Transmission", nil);
             NSString *xmit = [[NSUserDefaults standardUserDefaults] stringForKey:@"AudioTransmitMethod"];
             if ([xmit isEqualToString:@"vad"]) {
@@ -171,11 +169,10 @@
             [cell setSelectionStyle:UITableViewCellSelectionStyleNone];
             [tcpSwitch setOnTintColor:[UIColor blackColor]];
             [tcpSwitch addTarget:self action:@selector(forceTCPChanged:) forControlEvents:UIControlEventValueChanged];
-            [tcpSwitch release];
         } else if ([indexPath row] == 1) {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"PrefCertificateCell"];
             if (cell == nil)
-                cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"PrefCertificateCell"] autorelease];
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"PrefCertificateCell"];
             MKCertificate *cert = [MUCertificateController defaultCertificate];
             cell.textLabel.text = NSLocalizedString(@"Certificate", nil);
             cell.detailTextLabel.text = cert ? [cert subjectName] : NSLocalizedString(@"None", @"None (No certificate chosen)");
@@ -186,7 +183,7 @@
         } else if ([indexPath row] == 2) {
             UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"RemoteControlCell"];
             if (cell == nil)
-                cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"RemoteControlCell"] autorelease];
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"RemoteControlCell"];
             cell.textLabel.text = NSLocalizedString(@"Remote Control", nil);
             BOOL isOn = [[MURemoteControlServer sharedRemoteControlServer] isRunning];
             if (isOn) {
@@ -226,22 +223,18 @@
         if (indexPath.row == 1) { // Transmission
             MUAudioTransmissionPreferencesViewController *audioXmit = [[MUAudioTransmissionPreferencesViewController alloc] init];
             [self.navigationController pushViewController:audioXmit animated:YES];
-            [audioXmit release];
         } else if (indexPath.row == 2) { // Advanced
             MUAdvancedAudioPreferencesViewController *advAudio = [[MUAdvancedAudioPreferencesViewController alloc] init];
             [self.navigationController pushViewController:advAudio animated:YES];
-            [advAudio release];
         }
     } else if ([indexPath section] == 1) { // Network
         if ([indexPath row] == 1) { // Certificates
             MUCertificatePreferencesViewController *certPref = [[MUCertificatePreferencesViewController alloc] init];
             [self.navigationController pushViewController:certPref animated:YES];
-            [certPref release];
         }
         if ([indexPath row] == 2) { // Remote Control
             MURemoteControlPreferencesViewController *remoteControlPref = [[MURemoteControlPreferencesViewController alloc] init];
             [self.navigationController pushViewController:remoteControlPref animated:YES];
-            [remoteControlPref release];
         }
     }
 }

--- a/Source/Classes/MUPublicServerList.m
+++ b/Source/Classes/MUPublicServerList.m
@@ -33,10 +33,6 @@
     return self;
 }
 
-- (void) dealloc {
-    [super dealloc];
-}
-
 - (void) attemptUpdate {
     NSURLRequest *req = [NSURLRequest requestWithURL:[MKServices regionalServerListURL]];
     _conn = [[NSURLConnection alloc] initWithRequest:req delegate:self];
@@ -83,15 +79,6 @@
     return self;
 }
 
-- (void) dealloc {
-    [_serverListXML release];
-    [_modelContinents release];
-    [_modelCountries release];
-    [_continentNames release];
-    [_countryNames release];
-    [super dealloc];
-}
-
 - (void) parse {
     // Job's done.
     if (_parsed)
@@ -104,13 +91,10 @@
     NSXMLParser *parser = [[NSXMLParser alloc] initWithData:_serverListXML];
     [parser setDelegate:(id<NSXMLParserDelegate>)self];
     [parser parse];
-    [parser release];
 
     // Transform from NSDictionary representation to a NSArray-model
     NSArray *continentCodes = [[_continentNames allKeys] sortedArrayUsingSelector:@selector(compare:)];
-    [_modelContinents release];
     _modelContinents = [[NSMutableArray alloc] initWithCapacity:[continentCodes count]];
-    [_modelCountries release];
     _modelCountries = [[NSMutableArray alloc] init];
 
     for (NSString *key in continentCodes) {
@@ -132,8 +116,6 @@
         [_modelCountries addObject:countries];
     }
 
-    [_continentCountries release];
-    [_countryServers release];
     _continentCountries = nil;
     _countryServers = nil;
     _parsed = YES;
@@ -154,7 +136,7 @@
                 [_countryServers setObject:array forKey:countryCode];
             }
             // Add attribute dict to server array.
-            [array addObject:[attributeDict retain]];
+            [array addObject:attributeDict];
 
             // Extract the continent code of the country
             NSString *continentCode = [attributeDict objectForKey:@"continent_code"];

--- a/Source/Classes/MUPublicServerListController.h
+++ b/Source/Classes/MUPublicServerListController.h
@@ -6,5 +6,4 @@
 
 @interface MUPublicServerListController : UITableViewController
 - (id) init;
-- (void) dealloc;
 @end

--- a/Source/Classes/MUPublicServerListController.m
+++ b/Source/Classes/MUPublicServerListController.m
@@ -24,11 +24,6 @@
     return self;
 }
 
-- (void) dealloc {
-    [_serverList release];
-    [super dealloc];
-}
-
 - (void) viewWillAppear:(BOOL)animated {
     [super viewWillAppear:YES];
 
@@ -56,8 +51,6 @@
         UIBarButtonItem *barActivityIndicator = [[UIBarButtonItem alloc] initWithCustomView:activityIndicatorView];
         self.navigationItem.rightBarButtonItem = barActivityIndicator;
         [activityIndicatorView startAnimating];
-        [barActivityIndicator release];
-        [activityIndicatorView release];
     }
 }
 
@@ -104,7 +97,7 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"countryItem"];
     if (!cell) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"countryItem"] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"countryItem"];
     }
 
     [cell setAccessoryType:UITableViewCellAccessoryDisclosureIndicator];
@@ -127,7 +120,6 @@
 
     MUCountryServerListController *countryController = [[MUCountryServerListController alloc] initWithName:countryName serverList:countryServers];
     [[self navigationController] pushViewController:countryController animated:YES];
-    [countryController release];
 }
 
 @end

--- a/Source/Classes/MURemoteControlPreferencesViewController.m
+++ b/Source/Classes/MURemoteControlPreferencesViewController.m
@@ -62,13 +62,13 @@
     static NSString *CellIdentifier = @"RemoteControlPrefsCell";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:CellIdentifier] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:CellIdentifier];
     }
     
     if (indexPath.section == 0) {
         if (indexPath.row == 0) {
             cell.textLabel.text = @"Enable";
-            UISwitch *enableSwitch = [[[UISwitch alloc] initWithFrame:CGRectZero] autorelease];
+            UISwitch *enableSwitch = [[UISwitch alloc] initWithFrame:CGRectZero];
             [enableSwitch addTarget:self action:@selector(enableSwitchChanged:) forControlEvents:UIControlEventValueChanged];
             enableSwitch.on = [[MURemoteControlServer sharedRemoteControlServer] isRunning];
             enableSwitch.onTintColor = [UIColor blackColor];

--- a/Source/Classes/MURemoteControlServer.m
+++ b/Source/Classes/MURemoteControlServer.m
@@ -54,7 +54,7 @@ out:
 }
 
 static void acceptCallBack(CFSocketRef socket, CFSocketCallBackType type, CFDataRef address, const void *data, void *info) {
-    MURemoteControlServer *remoteControl = (MURemoteControlServer *) info;
+    MURemoteControlServer *remoteControl = (__bridge MURemoteControlServer *) info;
     int sock = *(int *)data;
     [remoteControl addSocket:[NSNumber numberWithInt:sock]];
     if (type == kCFSocketAcceptCallBack) {
@@ -96,10 +96,9 @@ static void acceptCallBack(CFSocketRef socket, CFSocketCallBackType type, CFData
 }
 
 - (BOOL) start {
-    [_activeSocks release];
     _activeSocks = [[NSMutableArray alloc] init];
     
-    CFSocketContext ctx = {0, self, NULL, NULL, NULL};
+    CFSocketContext ctx = {0, CFBridgingRetain(self), NULL, NULL, NULL};
     _sock = CFSocketCreate(NULL, PF_INET6, SOCK_STREAM, IPPROTO_TCP,
                            kCFSocketAcceptCallBack, (CFSocketCallBack)acceptCallBack, &ctx);
     if (_sock == NULL) {

--- a/Source/Classes/MUServerButton.m
+++ b/Source/Classes/MUServerButton.m
@@ -28,31 +28,18 @@
     return self;
 }
 
-- (void) dealloc {
-    [_hostname release];
-    [_port release];
-    [_username release];
-    [_displayname release];
-    [_pinger release];
-    [super dealloc];
-}
-
 - (void) setHighlighted:(BOOL)highlighted {
     [super setHighlighted:highlighted];
     [self setNeedsDisplay];
 }
 
 - (void) populateFromDisplayName:(NSString *)displayName hostName:(NSString *)hostName port:(NSString *)port {
-    [_displayname release];
     _displayname = [displayName copy];
-    
-    [_port release];
+
     _port = [port copy];
-    
-    [_pinger release];
+
     _pinger = nil;
-    
-    [_hostname release];
+
     if ([hostName length] > 0) {
         _hostname = [hostName copy];
         _pinger = [[MKServerPinger alloc] initWithHostname:_hostname port:_port];
@@ -65,23 +52,18 @@
 }
 
 - (void) populateFromFavouriteServer:(MUFavouriteServer *)favServ {
-    [_displayname release];
     _displayname = [[favServ displayName] copy];
-    
-    [_hostname release];
+
     _hostname = [[favServ hostName] copy];
-    
-    [_port release];
-    _port = [[NSString stringWithFormat:@"%lu", (unsigned long)[favServ port]] retain];
-    
-    [_username release];
+
+    _port = [NSString stringWithFormat:@"%lu", (unsigned long)[favServ port]];
+
     if ([[favServ userName] length] > 0) {
         _username = [[favServ userName] copy];
     } else {
         _username = [[[NSUserDefaults standardUserDefaults] objectForKey:@"DefaultUserName"] copy];
     }
-    
-    [_pinger release];
+
     _pinger = nil;
     if ([_hostname length] > 0) {
         _pinger = [[MKServerPinger alloc] initWithHostname:_hostname port:_port];

--- a/Source/Classes/MUServerCell.m
+++ b/Source/Classes/MUServerCell.m
@@ -26,26 +26,13 @@
     return [super initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:[MUServerCell reuseIdentifier]];
 }
 
-- (void) dealloc {    
-    [_hostname release];
-    [_port release];
-    [_username release];
-    [_displayname release];
-    [_pinger release];
-    [super dealloc];
-}
-
 - (void) populateFromDisplayName:(NSString *)displayName hostName:(NSString *)hostName port:(NSString *)port {
-    [_displayname release];
     _displayname = [displayName copy];
 
-    [_port release];
     _port = [port copy];
-    
-    [_pinger release];
+
     _pinger = nil;
-    
-    [_hostname release];
+
     if ([hostName length] > 0) {
         _hostname = [hostName copy];
         _pinger = [[MKServerPinger alloc] initWithHostname:_hostname port:_port];
@@ -60,23 +47,18 @@
 }
 
 - (void) populateFromFavouriteServer:(MUFavouriteServer *)favServ {
-    [_displayname release];
     _displayname = [[favServ displayName] copy];
 
-    [_hostname release];
     _hostname = [[favServ hostName] copy];
 
-    [_port release];
-    _port = [[NSString stringWithFormat:@"%lu", (unsigned long)[favServ port]] retain];
+    _port = [NSString stringWithFormat:@"%lu", (unsigned long)[favServ port]];
 
-    [_username release];
     if ([[favServ userName] length] > 0) {
         _username = [[favServ userName] copy];
     } else {
         _username = [[[NSUserDefaults standardUserDefaults] objectForKey:@"DefaultUserName"] copy];
     }
 
-    [_pinger release];
     _pinger = nil;
     if ([_hostname length] > 0) {
         _pinger = [[MKServerPinger alloc] initWithHostname:_hostname port:_port];

--- a/Source/Classes/MUServerCertificateTrustViewController.m
+++ b/Source/Classes/MUServerCertificateTrustViewController.m
@@ -36,7 +36,6 @@
                                                                      target:self
                                                                      action:@selector(dismissClicked:)];
     self.navigationItem.leftBarButtonItem = dismissButton;
-    [dismissButton release];
 }
 
 #pragma mark -

--- a/Source/Classes/MUServerRootViewController.m
+++ b/Source/Classes/MUServerRootViewController.m
@@ -53,8 +53,8 @@
 
 - (id) initWithConnection:(MKConnection *)conn andServerModel:(MKServerModel *)model {
     if ((self = [super init])) {
-        _connection = [conn retain];
-        _model = [model retain];
+        _connection = conn;
+        _model = model;
         [_model addDelegate:self];
         
         _unreadMessages = 0;
@@ -71,20 +71,8 @@
 }
 
 - (void) dealloc {
-    [_serverView release];
-    [_messagesView release];
-   
     [_model removeDelegate:self];
-    [_model release];
     [_connection setDelegate:nil];
-    [_connection release];
-    
-    [_menuButton release];
-    [_segmentedControl release];
-    [_smallIcon release];
-    [_numberBadgeView release];
-
-    [super dealloc];
 }
 
 - (void) takeOwnershipOfConnectionDelegate {
@@ -113,7 +101,7 @@
     _menuButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"MumbleMenuButton"] style:UIBarButtonItemStyleBordered target:self action:@selector(actionButtonClicked:)];
     _serverView.navigationItem.rightBarButtonItem = _menuButton;
     
-    UIButton *button = [[UIButton buttonWithType:UIButtonTypeCustom] retain];
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     [button setFrame:CGRectMake(0, 0, 35, 30)];
     [button setBackgroundImage:[UIImage imageNamed:@"SmallMumbleIcon"] forState:UIControlStateNormal];
     [button setAdjustsImageWhenDisabled:NO];
@@ -209,7 +197,6 @@
                                                   cancelButtonTitle:NSLocalizedString(@"OK", nil)
                                                   otherButtonTitles:nil];
         [alertView show];
-        [alertView release];
 
         [[MUConnectionController sharedController] disconnectFromServer];
     }
@@ -230,7 +217,6 @@
                                                    cancelButtonTitle:NSLocalizedString(@"OK", nil)
                                                   otherButtonTitles:nil];
         [alertView show];
-        [alertView release];
         
         [[MUConnectionController sharedController] disconnectFromServer];
     }
@@ -249,7 +235,6 @@
                                                   cancelButtonTitle:NSLocalizedString(@"OK", nil)
                                                   otherButtonTitles:nil];
         [alertView show];
-        [alertView release];
         
         [[MUConnectionController sharedController] disconnectFromServer];
     }
@@ -372,7 +357,6 @@
 
     [actionSheet setDelegate:self];
     [actionSheet showFromBarButtonItem:_menuButton animated:YES];
-    [actionSheet release];
 }
 
 - (void) childDoneButton:(id)sender {
@@ -405,23 +389,16 @@
         MUAudioMixerDebugViewController *audioMixerDebugViewController = [[MUAudioMixerDebugViewController alloc] init];
         UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:audioMixerDebugViewController];
         [self presentModalViewController:navCtrl animated:YES];
-        [audioMixerDebugViewController release];
-        [navCtrl release];
     } else if (buttonIndex == _accessTokensIndex) {
         MUAccessTokenViewController *tokenViewController = [[MUAccessTokenViewController alloc] initWithServerModel:_model];
         UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:tokenViewController];
         [self presentModalViewController:navCtrl animated:YES];
-        [tokenViewController release];
-        [navCtrl release];
     } else if (buttonIndex == _certificatesIndex) { // Certificates
         MUCertificateViewController *certView = [[MUCertificateViewController alloc] initWithCertificates:[_model serverCertificates]];
         UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:certView];
         UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(childDoneButton:)];
         certView.navigationItem.leftBarButtonItem = doneButton;
-        [doneButton release];
         [self presentModalViewController:navCtrl animated:YES];
-        [certView release];
-        [navCtrl release];
     } else if (buttonIndex == _selfRegisterIndex) { // Self-Register
         NSString *title = NSLocalizedString(@"User Registration", nil);
         NSString *msg = [NSString stringWithFormat:
@@ -437,7 +414,6 @@
                                                   cancelButtonTitle:NSLocalizedString(@"No", nil)
                                                   otherButtonTitles:NSLocalizedString(@"Yes", nil), nil];
         [alertView show];
-        [alertView release];
     } else if (buttonIndex == _clearMessagesIndex) { // Clear Messages
         [_messagesView clearAllMessages];
     } else if (buttonIndex == _selfMuteIndex) { // Self-Mute, Unmute Self

--- a/Source/Classes/MUServerViewController.m
+++ b/Source/Classes/MUServerViewController.m
@@ -22,7 +22,6 @@
 
 + (MUChannelNavigationItem *) navigationItemWithObject:(id)obj indentLevel:(NSInteger)indentLevel;
 - (id) initWithObject:(id)obj indentLevel:(NSInteger)indentLevel;
-- (void) dealloc;
 - (id) object;
 - (NSInteger) indentLevel;
 @end
@@ -30,7 +29,7 @@
 @implementation MUChannelNavigationItem
 
 + (MUChannelNavigationItem *) navigationItemWithObject:(id)obj indentLevel:(NSInteger)indentLevel {
-    return [[[MUChannelNavigationItem alloc] initWithObject:obj indentLevel:indentLevel] autorelease];
+    return [[MUChannelNavigationItem alloc] initWithObject:obj indentLevel:indentLevel];
 }
 
 - (id) initWithObject:(id)obj indentLevel:(NSInteger)indentLevel {
@@ -39,10 +38,6 @@
         _indentLevel = indentLevel;
     }
     return self;
-}
-
-- (void) dealloc {
-    [super dealloc];
 }
 
 - (id) object {
@@ -81,7 +76,7 @@
 
 - (id) initWithServerModel:(MKServerModel *)serverModel {
     if ((self = [super initWithStyle:UITableViewStylePlain])) {
-        _serverModel = [serverModel retain];
+        _serverModel = serverModel;
         [_serverModel addDelegate:self];
         _viewMode = MUServerViewControllerViewModeServer;
     }
@@ -90,8 +85,6 @@
 
 - (void) dealloc {
     [_serverModel removeDelegate:self];
-    [_serverModel release];
-    [super dealloc];
 }
 
 - (void) viewWillAppear:(BOOL)animated {
@@ -193,13 +186,10 @@
 }
 
 - (void) rebuildModelArrayFromChannel:(MKChannel *)channel {
-    [_modelItems release];
     _modelItems = [[NSMutableArray alloc] init];
-    
-    [_userIndexMap release];
+
     _userIndexMap = [[NSMutableDictionary alloc] init];
 
-    [_channelIndexMap release];
     _channelIndexMap = [[NSMutableDictionary alloc] init];
 
     [self addChannelTreeToModel:channel indentLevel:0];
@@ -212,14 +202,11 @@
 
 - (void) switchToChannelMode {
     _viewMode = MUServerViewControllerViewModeChannel;
-    
-    [_modelItems release];
+
     _modelItems = [[NSMutableArray alloc] init];
-    
-    [_userIndexMap release];
+
     _userIndexMap = [[NSMutableDictionary alloc] init];
-    
-    [_channelIndexMap release];
+
     _channelIndexMap = [[NSMutableDictionary alloc] init];
     
     MKChannel *channel = [[_serverModel connectedUser] channel];
@@ -268,9 +255,9 @@
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
         if (MUGetOperatingSystemVersion() >= MUMBLE_OS_IOS_7) {
-            cell = [[[MUServerTableViewCell alloc] initWithReuseIdentifier:CellIdentifier] autorelease];
+            cell = [[MUServerTableViewCell alloc] initWithReuseIdentifier:CellIdentifier];
         } else {
-            cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier] autorelease];
+            cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
         }
     }
 

--- a/Source/Classes/MUTableViewHeaderLabel.m
+++ b/Source/Classes/MUTableViewHeaderLabel.m
@@ -28,7 +28,7 @@
 }
 
 + (MUTableViewHeaderLabel *) labelWithText:(NSString *)text {
-    MUTableViewHeaderLabel *label = [[[MUTableViewHeaderLabel alloc] init] autorelease];
+    MUTableViewHeaderLabel *label = [[MUTableViewHeaderLabel alloc] init];
     label.text = text;
     return label;
 }

--- a/Source/Classes/MUTextMessage.m
+++ b/Source/Classes/MUTextMessage.m
@@ -13,21 +13,14 @@
 
 - (id) initWithHeading:(NSString *)heading andMessage:(NSString *)msg andDate:(NSDate *)date andEmbeddedLinks:(NSArray *)links andEmbeddedImages:(NSArray *)images andTimestampDate:(NSDate *)timestampDate andSentBySelf:(BOOL)sentBySelf {
     if ((self = [super init])) {
-        _heading = [heading retain];
-        _msg = [msg retain];
-        _date = [date retain];
+        _heading = heading;
+        _msg = msg;
+        _date = date;
         _self = sentBySelf;
-        _links = [links retain];
-        _images = [images retain];
+        _links = links;
+        _images = images;
     }
     return self;
-}
-
-- (void) dealloc {
-    [_heading release];
-    [_msg release];
-    [_date release];
-    [super dealloc];
 }
 
 - (NSString *) heading {
@@ -63,7 +56,7 @@
 }
 
 + (MUTextMessage *) textMessageWithHeading:(NSString *)heading andMessage:(NSString *)msg andEmbeddedLinks:(NSArray *)links andEmbeddedImages:(NSArray *)images andTimestampDate:(NSDate *)timestampDate isSentBySelf:(BOOL)sentBySelf {
-    return [[[MUTextMessage alloc] initWithHeading:heading andMessage:msg andDate:timestampDate andEmbeddedLinks:links andEmbeddedImages:images  andTimestampDate:timestampDate andSentBySelf:sentBySelf] autorelease];
+    return [[MUTextMessage alloc] initWithHeading:heading andMessage:msg andDate:timestampDate andEmbeddedLinks:links andEmbeddedImages:images  andTimestampDate:timestampDate andSentBySelf:sentBySelf];
 }
 
 @end

--- a/Source/Classes/MUUserStateAcessoryView.m
+++ b/Source/Classes/MUUserStateAcessoryView.m
@@ -40,11 +40,9 @@
         widthOffset -= iconWidth - xpos;
         imgView.frame = CGRectMake(ceilf(widthOffset), ceilf(ypos), img.size.width, img.size.height);
         [stateView addSubview:imgView];
-        [imgView release];
     }
-    
-    [states release];
-    return [stateView autorelease];
+
+    return stateView;
 }
 
 @end

--- a/Source/Classes/MUVersionChecker.h
+++ b/Source/Classes/MUVersionChecker.h
@@ -6,5 +6,4 @@
 
 @interface MUVersionChecker : NSObject
 - (id) init;
-- (void) dealloc;
 @end

--- a/Source/Classes/MUVersionChecker.m
+++ b/Source/Classes/MUVersionChecker.m
@@ -28,13 +28,6 @@
     return self;
 }
 
-- (void) dealloc {
-    [_conn cancel];
-    [_conn release];
-    [_buf release];
-    [super dealloc];
-}
-
 - (void) connection:(NSURLConnection *)conn didReceiveData:(NSData *)data {
     [_buf appendData:data];
 }
@@ -72,7 +65,6 @@
                                           cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
                                           otherButtonTitles:NSLocalizedString(@"Upgrade", nil), nil];
     [alert show];
-    [alert release];
 }
 
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {

--- a/Source/Classes/MUVoiceActivitySetupViewController.m
+++ b/Source/Classes/MUVoiceActivitySetupViewController.m
@@ -76,7 +76,7 @@
     
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
     }
     
     NSString *current = [[NSUserDefaults standardUserDefaults] stringForKey:@"AudioVADKind"];
@@ -93,19 +93,19 @@
         if (indexPath.row == 0) {
             cell.textLabel.text = NSLocalizedString(@"Amplitude", @"Amplitude voice-activity mode");
             if ([current isEqualToString:@"amplitude"]) {
-                cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+                cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
                 cell.textLabel.textColor = [MUColor selectedTextColor];
             }
         } else if (indexPath.row == 1) {
             cell.textLabel.text = NSLocalizedString(@"Signal to Noise", @"SNR voice-activity mode");
             if ([current isEqualToString:@"snr"]) {
-                cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+                cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
                 cell.textLabel.textColor = [MUColor selectedTextColor];
             }
         }
     } else if (section == 1) {
         if (indexPath.row == 0) {
-            MUAudioBarViewCell *cell = [[[MUAudioBarViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"AudioBarCell"] autorelease];
+            MUAudioBarViewCell *cell = [[MUAudioBarViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"AudioBarCell"];
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
             return cell;
         }
@@ -120,7 +120,6 @@
             [slider setMaximumTrackTintColor:[UIColor whiteColor]];
             [slider setMinimumTrackTintColor:[MUColor badPingColor]];
             cell.accessoryView = slider;
-            [slider release];
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
         } else if (indexPath.row == 1) {
             cell.textLabel.text = NSLocalizedString(@"Speech Above", @"Silence Above VAD configuration");
@@ -132,7 +131,6 @@
             [slider setMaximumTrackTintColor:[MUColor goodPingColor]];
             [slider setMinimumTrackTintColor:[UIColor whiteColor]];
             cell.accessoryView = slider;
-            [slider release];
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
         } else if (indexPath.row == 2) {
             cell.accessoryView = nil;
@@ -187,7 +185,7 @@
             [[NSUserDefaults standardUserDefaults] setObject:@"snr" forKey:@"AudioVADKind"];
         }
         cell = [self.tableView cellForRowAtIndexPath:indexPath];
-        cell.accessoryView = [[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]] autorelease];
+        cell.accessoryView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"GrayCheckmark"]];
         cell.textLabel.textColor = [MUColor selectedTextColor];
     }
     
@@ -207,7 +205,6 @@
                                                   cancelButtonTitle:NSLocalizedString(@"OK", nil)
                                                   otherButtonTitles:nil];
         [alertView show];
-        [alertView release];
     }
 }
 

--- a/Source/Classes/MUWelcomeScreenPad.m
+++ b/Source/Classes/MUWelcomeScreenPad.m
@@ -31,16 +31,13 @@
     _view = [[UIView alloc] initWithFrame:CGRectZero];
     _view.frame = CGRectMake(0, 0, 768, 1024);
     self.view = _view;
-    [_view release];
     
     _backgroundView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"BackgroundTextureBlackGradientPad"]];
     [_backgroundView setFrame:_view.frame];
     [_view addSubview:_backgroundView];
-    [_backgroundView release];
 
     _logoView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"LogoBigShadow"]];
     [_view addSubview:_logoView];
-    [_logoView release];
 
     _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
     _tableView.delegate = self;
@@ -51,7 +48,6 @@
     _tableView.scrollEnabled = NO;
     _tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     [_view addSubview:_tableView];
-    [_tableView release];
 }
 
 - (void) setViewPositions {
@@ -88,11 +84,9 @@
     
     UIBarButtonItem *aboutBtn = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"About", nil) style:UIBarButtonItemStyleBordered target:self action:@selector(aboutButtonClicked:)];
     self.navigationItem.rightBarButtonItem = aboutBtn;
-    [aboutBtn release];
     
     UIBarButtonItem *prefsBtn = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Preferences", nil) style:UIBarButtonItemStyleBordered target:self action:@selector(prefsButtonClicked:)];
     self.navigationItem.leftBarButtonItem = prefsBtn;
-    [prefsBtn release];
     
     [_tableView deselectRowAtIndexPath:[_tableView indexPathForSelectedRow] animated:animated];
 }
@@ -119,7 +113,7 @@
 - (UITableViewCell *) tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"welcomeItem"];
     if (!cell) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"welcomeItem"] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"welcomeItem"];
     }
     
     cell.selectionStyle = UITableViewCellSelectionStyleGray;
@@ -145,13 +139,13 @@
     /* Servers section. */
     if (indexPath.section == 0) {
         if (indexPath.row == 0) {
-            MUPublicServerListController *serverList = [[[MUPublicServerListController alloc] init] autorelease];
+            MUPublicServerListController *serverList = [[MUPublicServerListController alloc] init];
             [self.navigationController pushViewController:serverList animated:YES];
         } else if (indexPath.row == 1) {
-            MUFavouriteServerListController *favList = [[[MUFavouriteServerListController alloc] init] autorelease];
+            MUFavouriteServerListController *favList = [[MUFavouriteServerListController alloc] init];
             [self.navigationController pushViewController:favList animated:YES];
         } else if (indexPath.row == 2) {
-            MULanServerListController *lanList = [[[MULanServerListController alloc] init] autorelease];
+            MULanServerListController *lanList = [[MULanServerListController alloc] init];
             [self.navigationController pushViewController:lanList animated:YES];
         }
     }
@@ -167,9 +161,7 @@
         MULegalViewController *legalView = [[MULegalViewController alloc] init];
         UINavigationController *navController = [[UINavigationController alloc] init];
         [navController pushViewController:legalView animated:NO];
-        [legalView release];
         [[self navigationController] presentModalViewController:navController animated:YES];
-        [navController release];
     } else if (buttonIndex == 3) {
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"mailto:support@mumbleapp.com"]];
     }
@@ -194,7 +186,6 @@
                               NSLocalizedString(@"Legal", nil),
                               NSLocalizedString(@"Support", nil), nil];
     [aboutView show];
-    [aboutView release];
 }
 
 - (void) prefsButtonClicked:(id)sender {
@@ -202,8 +193,8 @@
         return;
     }
     
-    MUPreferencesViewController *prefs = [[[MUPreferencesViewController alloc] init] autorelease];
-    UINavigationController *navCtrl = [[[UINavigationController alloc] initWithRootViewController:prefs] autorelease];
+    MUPreferencesViewController *prefs = [[MUPreferencesViewController alloc] init];
+    UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:prefs];
     UIPopoverController *popOver = [[UIPopoverController alloc] initWithContentViewController:navCtrl];
     popOver.popoverBackgroundViewClass = [MUPopoverBackgroundView class];
     popOver.delegate = self;
@@ -216,7 +207,6 @@
 
 - (void) popoverControllerDidDismissPopover:(UIPopoverController *)popoverController {
     if (popoverController == _prefsPopover) {
-        [_prefsPopover release];
         _prefsPopover = nil;
     }
 }

--- a/Source/Classes/MUWelcomeScreenPhone.h
+++ b/Source/Classes/MUWelcomeScreenPhone.h
@@ -4,5 +4,4 @@
 
 @interface MUWelcomeScreenPhone : UITableViewController
 - (id) init;
-- (void) dealloc;
 @end

--- a/Source/Classes/MUWelcomeScreenPhone.m
+++ b/Source/Classes/MUWelcomeScreenPhone.m
@@ -34,10 +34,6 @@
     return self;
 }
 
-- (void) dealloc {
-    [super dealloc];
-}
-
 - (void) viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
 
@@ -69,14 +65,12 @@
                                                              target:self
                                                              action:@selector(aboutClicked:)];
     [self.navigationItem setRightBarButtonItem:about];
-    [about release];
     
     UIBarButtonItem *prefs = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Preferences", nil)
                                                               style:UIBarButtonItemStyleBordered
                                                              target:self
                                                              action:@selector(prefsClicked:)];
     [self.navigationItem setLeftBarButtonItem:prefs];
-    [prefs release];
 #endif
 }
 
@@ -103,7 +97,7 @@
 
 - (UIView *) tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
     UIImage *img = [MUImage imageNamed:@"WelcomeScreenIcon"];
-    UIImageView *imgView = [[[UIImageView alloc] initWithImage:img] autorelease];
+    UIImageView *imgView = [[UIImageView alloc] initWithImage:img];
     [imgView setContentMode:UIViewContentModeCenter];
     [imgView setFrame:CGRectMake(0, 0, img.size.width, img.size.height)];
     return imgView;
@@ -126,7 +120,7 @@
 - (UITableViewCell *) tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"welcomeItem"];
     if (!cell) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"welcomeItem"] autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"welcomeItem"];
     }
     
     cell.selectionStyle = UITableViewCellSelectionStyleGray;
@@ -152,13 +146,13 @@
     /* Servers section. */
     if (indexPath.section == 0) {
         if (indexPath.row == 0) {
-            MUPublicServerListController *serverList = [[[MUPublicServerListController alloc] init] autorelease];
+            MUPublicServerListController *serverList = [[MUPublicServerListController alloc] init];
             [self.navigationController pushViewController:serverList animated:YES];
         } else if (indexPath.row == 1) {
-            MUFavouriteServerListController *favList = [[[MUFavouriteServerListController alloc] init] autorelease];
+            MUFavouriteServerListController *favList = [[MUFavouriteServerListController alloc] init];
             [self.navigationController pushViewController:favList animated:YES];
         } else if (indexPath.row == 2) {
-            MULanServerListController *lanList = [[[MULanServerListController alloc] init] autorelease];
+            MULanServerListController *lanList = [[MULanServerListController alloc] init];
             [self.navigationController pushViewController:lanList animated:YES];
         }
     }
@@ -181,11 +175,10 @@
                                                                 NSLocalizedString(@"Legal", nil),
                                                                 NSLocalizedString(@"Support", nil), nil];
     [aboutView show];
-    [aboutView release];
 }
 
 - (void) prefsClicked:(id)sender {
-    MUPreferencesViewController *prefs = [[[MUPreferencesViewController alloc] init] autorelease];
+    MUPreferencesViewController *prefs = [[MUPreferencesViewController alloc] init];
     [self.navigationController pushViewController:prefs animated:YES];
 }
 
@@ -199,9 +192,7 @@
         MULegalViewController *legalView = [[MULegalViewController alloc] init];
         UINavigationController *navController = [[UINavigationController alloc] init];
         [navController pushViewController:legalView animated:NO];
-        [legalView release];
         [[self navigationController] presentModalViewController:navController animated:YES];
-        [navController release];
     } else if (buttonIndex == 3) {
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"mailto:support@mumbleapp.com"]];
     }

--- a/Source/main.m
+++ b/Source/main.m
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 
 int main(int argc, char *argv[]) {
-    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-    int retVal = UIApplicationMain(argc, argv, @"UIApplication", @"MUApplicationDelegate");
-    [pool release];
-    return retVal;
+    @autoreleasepool {
+        int retVal = UIApplicationMain(argc, argv, @"UIApplication", @"MUApplicationDelegate");
+        return retVal;
+    }
 }


### PR DESCRIPTION
According to [this post from 2021](https://developer.apple.com/forums/thread/673960), new XCode projects have had automatic reference counting (ARC) enabled by default "for quite a while" (Couldn't find the exact XCode version that changed the default).

Unfortunately, the migration tooling isn't available in XCode 16 anymore, so i just went ahead and removed everything the compiler errors ended up complaining about, which is most of the work when enabling ARC.

I added some exceptions for the certificate related code, because it interacts a lot with the Security framework, which requires additional bridging rituals I don't really feel confident about for now.

What I also haven't checked is whether there are any properties that need to be annotated to avoid retain cycles.
For what it's worth, these cycles cause increased memory usage and/or memory leaks at worst.

Given the age of the app, and consequentially its low memory footprint (as it ran fine on ancient devices without much RAM), I think the impact of a few new memory leaks should be fine for now on modern devices.

I think it's worth it just for making the code a little bit more like what iOS devs are (probably) used to nowadays ;)