### PR TITLE
Fix some easy deprecations/warnings

### DIFF
--- a/Dependencies/MKNumberBadgeView/MKNumberBadgeView.h
+++ b/Dependencies/MKNumberBadgeView/MKNumberBadgeView.h
@@ -47,7 +47,7 @@
     
     CGSize _shadowOffset;
 	
-	UITextAlignment _alignment;
+    NSTextAlignment _alignment;
 }
 
 // The current value displayed in the badge. Updating the value will update the view's display
@@ -76,7 +76,7 @@
 @property (retain,nonatomic) UIColor* textColor;
 
 // How the badge image hould be aligned horizontally in the view. 
-@property (assign,nonatomic) UITextAlignment alignment;
+@property (assign,nonatomic) NSTextAlignment alignment;
 
 // Returns the visual size of the badge for the current value. Not the same hing as the size of the view's bounds.
 // The badge view bounds should be wider than space needed to draw the badge.

--- a/Dependencies/MKNumberBadgeView/MKNumberBadgeView.m
+++ b/Dependencies/MKNumberBadgeView/MKNumberBadgeView.m
@@ -78,7 +78,7 @@
 	self.shadow = YES;
 	self.shadowOffset = CGSizeMake(0, -3);
 	self.shine = YES;
-	self.alignment = UITextAlignmentCenter;
+	self.alignment = NSTextAlignmentCenter;
 	self.fillColor = [UIColor redColor];
 	self.strokeColor = [UIColor whiteColor];
 	self.textColor = [UIColor whiteColor];
@@ -124,13 +124,13 @@
 	switch (self.alignment) 
 	{
 		default:
-		case UITextAlignmentCenter:
+		case NSTextAlignmentCenter:
 			ctm = CGPointMake( round((viewBounds.size.width - badgeRect.size.width)/2), round((viewBounds.size.height - badgeRect.size.height)/2) );
 			break;
-		case UITextAlignmentLeft:
+		case NSTextAlignmentLeft:
 			ctm = CGPointMake( 0, round((viewBounds.size.height - badgeRect.size.height)/2) );
 			break;
-		case UITextAlignmentRight:
+		case NSTextAlignmentRight:
 			ctm = CGPointMake( (viewBounds.size.width - badgeRect.size.width), round((viewBounds.size.height - badgeRect.size.height)/2) );
 			break;
 	}

--- a/Dependencies/MKNumberBadgeView/MKNumberBadgeView.m
+++ b/Dependencies/MKNumberBadgeView/MKNumberBadgeView.m
@@ -95,8 +95,7 @@
 
 	NSString* numberString = [NSString stringWithFormat:@"%lu", (unsigned long)self.value];
 	
-	
-	CGSize numberSize = [numberString sizeWithFont:self.font];
+    CGSize numberSize = [numberString sizeWithAttributes: @{ NSFontAttributeName : self.font }];
 		
 	CGPathRef badgePath = [self newBadgePathForTextSize:numberSize];
 	
@@ -208,10 +207,9 @@
 	CGContextSetFillColorWithColor( curContext, self.textColor.CGColor );
 		
 	CGPoint textPt = CGPointMake( ctm.x + (badgeRect.size.width - numberSize.width)/2 , ctm.y + (badgeRect.size.height - numberSize.height)/2 );
-	
-	[numberString drawAtPoint:textPt withFont:self.font];
-
-	CGContextRestoreGState( curContext );
+    
+    [numberString drawAtPoint:textPt withAttributes: @{ NSFontAttributeName : self.font }];
+    CGContextRestoreGState( curContext );
 
 }
 
@@ -259,8 +257,7 @@
 	NSString* numberString = [NSString stringWithFormat:@"%lu",(unsigned long)self.value];
 	
 	
-	CGSize numberSize = [numberString sizeWithFont:self.font];
-	
+    CGSize numberSize = [numberString sizeWithAttributes: @{ NSFontAttributeName : self.font }];
 	CGPathRef badgePath = [self newBadgePathForTextSize:numberSize];
 	
 	CGRect badgeRect = CGPathGetBoundingBox(badgePath);

--- a/Source/Classes/MUAccessTokenViewController.m
+++ b/Source/Classes/MUAccessTokenViewController.m
@@ -5,7 +5,7 @@
 #import "MUAccessTokenViewController.h"
 #import "MUDatabase.h"
 #import "MUOperatingSystem.h"
-#import "MUBAckgroundView.h"
+#import "MUBackgroundView.h"
 
 @interface MUAccessTokenViewController () {
     MKServerModel    *_model;

--- a/Source/Classes/MUAccessTokenViewController.m
+++ b/Source/Classes/MUAccessTokenViewController.m
@@ -182,7 +182,7 @@
 }
 
 - (void) doneButtonClicked:(id)sender {
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark -

--- a/Source/Classes/MUAdvancedAudioPreferencesViewController.m
+++ b/Source/Classes/MUAdvancedAudioPreferencesViewController.m
@@ -18,7 +18,7 @@
 
 - (id) init {
     if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
-        self.contentSizeForViewInPopover = CGSizeMake(320, 480);
+        self.preferredContentSize = CGSizeMake(320, 480);
     }
     return self;
 }

--- a/Source/Classes/MUAdvancedAudioPreferencesViewController.m
+++ b/Source/Classes/MUAdvancedAudioPreferencesViewController.m
@@ -221,7 +221,7 @@
                 NSString *echoCancelNotAvail = NSLocalizedString(@"Echo Cancellation is not available when using the current audio peripheral.", nil);
                 MUTableViewHeaderLabel *lbl = [MUTableViewHeaderLabel labelWithText:echoCancelNotAvail];
                 lbl.font = [UIFont systemFontOfSize:16.0f];
-                lbl.lineBreakMode = UILineBreakModeWordWrap;
+                lbl.lineBreakMode = NSLineBreakByWordWrapping;
                 lbl.numberOfLines = 0;
                 return lbl;
             }

--- a/Source/Classes/MUApplicationDelegate.m
+++ b/Source/Classes/MUApplicationDelegate.m
@@ -136,7 +136,7 @@
     return NO;
 }
 
-- (BOOL) application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
+- (BOOL) application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
     if ([[url scheme] isEqualToString:@"mumble"]) {
         MUConnectionController *connController = [MUConnectionController sharedController];
         if ([connController isConnected]) {

--- a/Source/Classes/MUAudioMixerDebugViewController.m
+++ b/Source/Classes/MUAudioMixerDebugViewController.m
@@ -100,7 +100,7 @@
 }
 
 - (void) doneDebugging:(id)sender {
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end

--- a/Source/Classes/MUAudioQualityPreferencesViewController.m
+++ b/Source/Classes/MUAudioQualityPreferencesViewController.m
@@ -13,7 +13,7 @@
 
 - (id) init {
     if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
-        self.contentSizeForViewInPopover = CGSizeMake(320, 480);
+        self.preferredContentSize = CGSizeMake(320, 480);
     }
     return self;
 }

--- a/Source/Classes/MUAudioSidetonePreferencesViewController.m
+++ b/Source/Classes/MUAudioSidetonePreferencesViewController.m
@@ -13,7 +13,7 @@
 
 - (id) init {
     if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
-        self.contentSizeForViewInPopover = CGSizeMake(320, 480);
+        self.preferredContentSize = CGSizeMake(320, 480);
     }
     return self;
 }

--- a/Source/Classes/MUAudioTransmissionPreferencesViewController.m
+++ b/Source/Classes/MUAudioTransmissionPreferencesViewController.m
@@ -19,7 +19,7 @@
 
 - (id) init {
     if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
-        self.contentSizeForViewInPopover = CGSizeMake(320, 480);
+        self.preferredContentSize = CGSizeMake(320, 480);
     }
     return self;
 }

--- a/Source/Classes/MUAudioTransmissionPreferencesViewController.m
+++ b/Source/Classes/MUAudioTransmissionPreferencesViewController.m
@@ -162,7 +162,7 @@
         UIView *parentView = [[UIView alloc] initWithFrame:CGRectZero];
         MUTableViewHeaderLabel *lbl = [MUTableViewHeaderLabel labelWithText:nil];
         lbl.font = [UIFont systemFontOfSize:16.0f];
-        lbl.lineBreakMode = UILineBreakModeWordWrap;
+        lbl.lineBreakMode = NSLineBreakByWordWrapping;
         lbl.numberOfLines = 0;
         lbl.contentMode = UIViewContentModeTop;
         if ([current isEqualToString:@"vad"]) {

--- a/Source/Classes/MUCertificateCreationView.m
+++ b/Source/Classes/MUCertificateCreationView.m
@@ -252,7 +252,7 @@ static void ShowAlertDialog(NSString *title, NSString *msg) {
 #pragma mark Target/actions
 
 - (void) cancelClicked:(id)sender {
-    [[self navigationController] dismissModalViewControllerAnimated:YES];
+    [[self navigationController] dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void) createClicked:(id)sender {
@@ -324,7 +324,7 @@ static void ShowAlertDialog(NSString *title, NSString *msg) {
         }
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            [[self navigationController] dismissModalViewControllerAnimated:YES];
+            [[self navigationController] dismissViewControllerAnimated:YES completion:nil];
         });
     });    
 }

--- a/Source/Classes/MUCertificateCreationView.m
+++ b/Source/Classes/MUCertificateCreationView.m
@@ -51,7 +51,7 @@ static void ShowAlertDialog(NSString *title, NSString *msg) {
 
 - (id) init {
     if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
-        [self setContentSizeForViewInPopover:CGSizeMake(320, 480)];
+        self.preferredContentSize = CGSizeMake(320, 480);
         
         NSString *name = NSLocalizedString(@"Name", nil);
         NSString *defaultName = NSLocalizedString(@"Mumble User", nil);

--- a/Source/Classes/MUCertificateCreationView.m
+++ b/Source/Classes/MUCertificateCreationView.m
@@ -69,7 +69,7 @@ static void ShowAlertDialog(NSString *title, NSString *msg) {
         [_nameField addTarget:self action:@selector(textFieldDidEndOnExit:) forControlEvents:UIControlEventEditingDidEndOnExit];
         [_nameField setReturnKeyType:UIReturnKeyNext];
         [_nameField setAdjustsFontSizeToFitWidth:NO];
-        [_nameField setTextAlignment:UITextAlignmentLeft];
+        [_nameField setTextAlignment:NSTextAlignmentLeft];
         [_nameField setPlaceholder:defaultName];
         [_nameField setAutocapitalizationType:UITextAutocapitalizationTypeWords];
         [_nameField setText:_fullName];
@@ -89,7 +89,7 @@ static void ShowAlertDialog(NSString *title, NSString *msg) {
         [_emailField addTarget:self action:@selector(textFieldDidEndOnExit:) forControlEvents:UIControlEventEditingDidEndOnExit];
         [_emailField setReturnKeyType:UIReturnKeyDefault];
         [_emailField setAdjustsFontSizeToFitWidth:NO];
-        [_emailField setTextAlignment:UITextAlignmentLeft];
+        [_emailField setTextAlignment:NSTextAlignmentLeft];
         [_emailField setPlaceholder:optional];
         [_emailField setAutocapitalizationType:UITextAutocapitalizationTypeWords];
         [_emailField setKeyboardType:UIKeyboardTypeEmailAddress];

--- a/Source/Classes/MUCertificateDiskImportViewController.m
+++ b/Source/Classes/MUCertificateDiskImportViewController.m
@@ -334,7 +334,7 @@ static void ShowAlertDialog(NSString *title, NSString *msg) {
 #pragma mark - Actions
 
 - (void) doneClicked:(id)sender {
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void) showRemoveAlert {

--- a/Source/Classes/MUCertificateDiskImportViewController.m
+++ b/Source/Classes/MUCertificateDiskImportViewController.m
@@ -147,7 +147,7 @@ static void ShowAlertDialog(NSString *title, NSString *msg) {
                                            @"Help text for iTunes File Transfer (iTunes Import)");
         MUTableViewHeaderLabel *lbl = [MUTableViewHeaderLabel labelWithText:help];
         lbl.font = [UIFont systemFontOfSize:16.0f];
-        lbl.lineBreakMode = UILineBreakModeWordWrap;
+        lbl.lineBreakMode = NSLineBreakByWordWrapping;
         lbl.numberOfLines = 0;
         return lbl;
     }

--- a/Source/Classes/MUCertificateDiskImportViewController.m
+++ b/Source/Classes/MUCertificateDiskImportViewController.m
@@ -33,7 +33,7 @@ static void ShowAlertDialog(NSString *title, NSString *msg) {
 @implementation MUCertificateDiskImportViewController
 
 - (id) init {
-    self.contentSizeForViewInPopover = CGSizeMake(320, 480);
+    self.preferredContentSize = CGSizeMake(320, 480);
     
     UITableViewStyle style = UITableViewStyleGrouped;
     NSArray *documentDirs = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);

--- a/Source/Classes/MUCertificatePreferencesViewController.m
+++ b/Source/Classes/MUCertificatePreferencesViewController.m
@@ -30,7 +30,7 @@
 
 - (id) init {
     if ((self = [super initWithStyle:UITableViewStylePlain])) {
-        [self setContentSizeForViewInPopover:CGSizeMake(320, 480)];
+        self.preferredContentSize = CGSizeMake(320, 480);
         _showAll = [[[NSUserDefaults standardUserDefaults] objectForKey:@"CertificatesShowIntermediates"] boolValue];
     }
     return self;

--- a/Source/Classes/MUCertificatePreferencesViewController.m
+++ b/Source/Classes/MUCertificatePreferencesViewController.m
@@ -203,7 +203,7 @@
         navCtrl.modalPresentationStyle = UIModalPresentationCurrentContext;
         MUCertificateCreationView *certGen = [[MUCertificateCreationView alloc] init];
         [navCtrl pushViewController:certGen animated:NO];
-        [[self navigationController] presentModalViewController:navCtrl animated:YES];
+        [[self navigationController] presentViewController:navCtrl animated:YES completion:nil];
     } else if (idx == 1) { // Show All Certificates; Show Identities Only
         _showAll = !_showAll;
         [[NSUserDefaults standardUserDefaults] setBool:_showAll forKey:@"CertificatesShowIntermediates"];
@@ -212,7 +212,7 @@
     } else if (idx == 2) { // Import From iTunes
         MUCertificateDiskImportViewController *diskImportViewController = [[MUCertificateDiskImportViewController alloc] init];
         UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:diskImportViewController];
-        [[self navigationController] presentModalViewController:navController animated:YES];
+        [[self navigationController] presentViewController:navController animated:YES completion:nil];
     }
 }
 

--- a/Source/Classes/MUCertificateViewController.m
+++ b/Source/Classes/MUCertificateViewController.m
@@ -292,7 +292,7 @@ static const NSUInteger CertificateViewSectionTotal              = 4;
             cell.textLabel.textColor = [MUColor selectedTextColor];
             cell.textLabel.font = [UIFont fontWithName:@"Courier" size:16];
             cell.textLabel.numberOfLines = 0;
-            cell.textLabel.lineBreakMode = UILineBreakModeWordWrap;
+            cell.textLabel.lineBreakMode = NSLineBreakByWordWrapping;
             cell.selectionStyle = UITableViewCellSelectionStyleGray;
         }
     } else if (section == CertificateViewSectionSHA256Fingerprint) {
@@ -303,7 +303,7 @@ static const NSUInteger CertificateViewSectionTotal              = 4;
             cell.textLabel.textColor = [MUColor selectedTextColor];
             cell.textLabel.font = [UIFont fontWithName:@"Courier" size:16];
             cell.textLabel.numberOfLines = 0;
-            cell.textLabel.lineBreakMode = UILineBreakModeWordWrap;
+            cell.textLabel.lineBreakMode = NSLineBreakByWordWrapping;
             cell.selectionStyle = UITableViewCellSelectionStyleGray;
         }
     } else {
@@ -316,7 +316,7 @@ static const NSUInteger CertificateViewSectionTotal              = 4;
         cell.textLabel.textColor = [UIColor blackColor];
         cell.textLabel.font = [UIFont boldSystemFontOfSize:17];
         cell.textLabel.numberOfLines = 1;
-        cell.textLabel.lineBreakMode = UILineBreakModeTailTruncation;
+        cell.textLabel.lineBreakMode = NSLineBreakByTruncatingTail;
         cell.detailTextLabel.text = [item objectAtIndex:1];
         cell.detailTextLabel.textColor = [MUColor selectedTextColor];
         cell.selectionStyle = UITableViewCellSelectionStyleGray;

--- a/Source/Classes/MUCertificateViewController.m
+++ b/Source/Classes/MUCertificateViewController.m
@@ -38,7 +38,7 @@ static const NSUInteger CertificateViewSectionTotal              = 4;
 
 - (id) initWithPersistentRef:(NSData *)persistentRef {
     if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
-        self.contentSizeForViewInPopover = CGSizeMake(320, 480);
+        self.preferredContentSize = CGSizeMake(320, 480);
         
         // Try to build a chain, if possible.
         NSArray *chains = [MUCertificateChainBuilder buildChainFromPersistentRef:persistentRef];
@@ -63,7 +63,7 @@ static const NSUInteger CertificateViewSectionTotal              = 4;
     if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
         _certificates = [[NSArray alloc] initWithObjects:cert, nil];
         _curIdx = 0;
-        [self setContentSizeForViewInPopover:CGSizeMake(320, 480)];
+        self.preferredContentSize = CGSizeMake(320, 480);
     }
     return self;
 }
@@ -72,7 +72,7 @@ static const NSUInteger CertificateViewSectionTotal              = 4;
     if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
         _certificates = [[NSArray alloc] initWithArray:cert];
         _curIdx = 0;
-        [self setContentSizeForViewInPopover:CGSizeMake(320, 480)];
+        self.preferredContentSize = CGSizeMake(320, 480);
     }
     return self;
 }

--- a/Source/Classes/MUCertificateViewController.m
+++ b/Source/Classes/MUCertificateViewController.m
@@ -121,7 +121,7 @@ static const NSUInteger CertificateViewSectionTotal              = 4;
     }
     
     UIBarButtonItem *actions = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(actionClicked:)];
-    [actions setStyle:UIBarButtonItemStyleBordered];
+    [actions setStyle:UIBarButtonItemStylePlain];
     [actions autorelease];
 
     // If there's more than one certificate in the chain, show the arrows

--- a/Source/Classes/MUCertificateViewController.m
+++ b/Source/Classes/MUCertificateViewController.m
@@ -99,7 +99,6 @@ static const NSUInteger CertificateViewSectionTotal              = 4;
                     [UIImage imageNamed:@"up.png"],
                     [UIImage imageNamed:@"down.png"],
                 nil]];
-        _arrows.segmentedControlStyle = UISegmentedControlStyleBar;
         _arrows.momentary = YES;
         [_arrows addTarget:self action:@selector(certificateSwitch:) forControlEvents:UIControlEventValueChanged];
     }

--- a/Source/Classes/MUConnectionController.m
+++ b/Source/Classes/MUConnectionController.m
@@ -80,7 +80,7 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
 }
 
 - (void) disconnectFromServer {
-    [_serverRoot dismissModalViewControllerAnimated:YES];
+    [_serverRoot dismissViewControllerAnimated:YES completion:nil];
     [self teardownConnection];
 }
 
@@ -371,7 +371,7 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
         }
     }
 
-    [_parentViewController presentModalViewController:_serverRoot animated:YES];
+    [_parentViewController presentViewController:_serverRoot animated:YES completion:nil];
     _parentViewController = nil;
 }
 
@@ -441,7 +441,7 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
         MUServerCertificateTrustViewController *certTrustView = [[MUServerCertificateTrustViewController alloc] initWithCertificates:[_connection peerCertificates]];
         [certTrustView setDelegate:self];
         UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:certTrustView];
-        [_parentViewController presentModalViewController:navCtrl animated:YES];
+        [_parentViewController presentViewController:navCtrl animated:YES completion:nil];
     }
 }
 

--- a/Source/Classes/MUCountryServerListController.m
+++ b/Source/Classes/MUCountryServerListController.m
@@ -176,7 +176,7 @@
     [editView setDoneAction:@selector(doneButtonClicked:)];
     [modalNav pushViewController:editView animated:NO];
 
-    [[self navigationController] presentModalViewController:modalNav animated:YES];
+    [[self navigationController] presentViewController:modalNav animated:YES completion:nil];
 }
 
 - (void) doneButtonClicked:(id)sender {

--- a/Source/Classes/MUFavouriteServerEditViewController.m
+++ b/Source/Classes/MUFavouriteServerEditViewController.m
@@ -71,7 +71,7 @@
         [_descriptionField addTarget:self action:@selector(textFieldDidEndOnExit:) forControlEvents:UIControlEventEditingDidEndOnExit];
         [_descriptionField setReturnKeyType:UIReturnKeyNext];
         [_descriptionField setAdjustsFontSizeToFitWidth:NO];
-        [_descriptionField setTextAlignment:UITextAlignmentLeft];
+        [_descriptionField setTextAlignment:NSTextAlignmentLeft];
         [_descriptionField setPlaceholder:NSLocalizedString(@"Mumble Server", nil)];
         [_descriptionField setAutocapitalizationType:UITextAutocapitalizationTypeWords];
         [_descriptionField setText:[_favourite displayName]];
@@ -91,7 +91,7 @@
         [_addressField addTarget:self action:@selector(textFieldDidEndOnExit:) forControlEvents:UIControlEventEditingDidEndOnExit];
         [_addressField setReturnKeyType:UIReturnKeyNext];
         [_addressField setAdjustsFontSizeToFitWidth:NO];
-        [_addressField setTextAlignment:UITextAlignmentLeft];
+        [_addressField setTextAlignment:NSTextAlignmentLeft];
         [_addressField setPlaceholder:NSLocalizedString(@"Hostname or IP address", nil)];
         [_addressField setAutocapitalizationType:UITextAutocapitalizationTypeNone];
         [_addressField setAutocorrectionType:UITextAutocorrectionTypeNo];
@@ -115,7 +115,7 @@
         [_portField setAdjustsFontSizeToFitWidth:YES];
         [_portField setAutocapitalizationType:UITextAutocapitalizationTypeNone];
         [_portField setAutocorrectionType:UITextAutocorrectionTypeNo];
-        [_portField setTextAlignment:UITextAlignmentLeft];
+        [_portField setTextAlignment:NSTextAlignmentLeft];
         [_portField setPlaceholder:@"64738"];
         [_portField setKeyboardType:UIKeyboardTypeNumbersAndPunctuation];
         if ([_favourite port] != 0)
@@ -140,7 +140,7 @@
         [_usernameField setAdjustsFontSizeToFitWidth:NO];
         [_usernameField setAutocapitalizationType:UITextAutocapitalizationTypeNone];
         [_usernameField setAutocorrectionType:UITextAutocorrectionTypeNo];
-        [_usernameField setTextAlignment:UITextAlignmentLeft];
+        [_usernameField setTextAlignment:NSTextAlignmentLeft];
         [_usernameField setPlaceholder:[[NSUserDefaults standardUserDefaults] objectForKey:@"DefaultUserName"]];
         [_usernameField setSecureTextEntry:NO];
         [_usernameField setText:[_favourite userName]];
@@ -164,7 +164,7 @@
         [_passwordField setAutocorrectionType:UITextAutocorrectionTypeNo];
         [_passwordField setPlaceholder:NSLocalizedString(@"Optional", nil)];
         [_passwordField setSecureTextEntry:YES];
-        [_passwordField setTextAlignment:UITextAlignmentLeft];
+        [_passwordField setTextAlignment:NSTextAlignmentLeft];
         [_passwordField setText:[_favourite password]];
         [_passwordField setClearButtonMode:UITextFieldViewModeWhileEditing];
         [[_passwordCell contentView] addSubview:_passwordField];

--- a/Source/Classes/MUFavouriteServerEditViewController.m
+++ b/Source/Classes/MUFavouriteServerEditViewController.m
@@ -279,7 +279,7 @@
 #pragma mark UIBarButton actions
 
 - (void) cancelClicked:(id)sender {
-    [[self navigationController] dismissModalViewControllerAnimated:YES];
+    [[self navigationController] dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void) doneClicked:(id)sender {
@@ -294,7 +294,7 @@
 
     // Get rid of oureslves and call back to our target to tell it that
     // we're done.
-    [[self navigationController] dismissModalViewControllerAnimated:YES];
+    [[self navigationController] dismissViewControllerAnimated:YES completion:nil];
     if ([_target respondsToSelector:_doneAction]) {
         [_target performSelector:_doneAction withObject:self];
     }

--- a/Source/Classes/MUFavouriteServerListController.m
+++ b/Source/Classes/MUFavouriteServerListController.m
@@ -212,7 +212,7 @@
     [modalNav pushViewController:editView animated:NO];
     
     modalNav.modalPresentationStyle = UIModalPresentationFormSheet;
-    [[self navigationController] presentModalViewController:modalNav animated:YES];
+    [[self navigationController] presentViewController:modalNav animated:YES completion:nil];
 }
 
 - (void) presentEditDialogForFavourite:(MUFavouriteServer *)favServ {
@@ -228,7 +228,7 @@
     [modalNav pushViewController:editView animated:NO];
     
     modalNav.modalPresentationStyle = UIModalPresentationFormSheet;
-    [[self navigationController] presentModalViewController:modalNav animated:YES];
+    [[self navigationController]presentViewController:modalNav animated:YES completion:nil];
 }
 
 #pragma mark -

--- a/Source/Classes/MULanServerListController.m
+++ b/Source/Classes/MULanServerListController.m
@@ -184,7 +184,7 @@ static NSInteger NetServiceAlphabeticalSort(id arg1, id arg2, void *reverse) {
     [editView setDoneAction:@selector(doneButtonClicked:)];
     [modalNav pushViewController:editView animated:NO];
     
-    [[self navigationController] presentModalViewController:modalNav animated:YES];
+    [[self navigationController] presentViewController:modalNav animated:YES completion:nil];
 }
 
 - (void) doneButtonClicked:(id)sender {

--- a/Source/Classes/MULegalViewController.m
+++ b/Source/Classes/MULegalViewController.m
@@ -54,7 +54,7 @@
 }
 
 - (void) doneButtonClicked:(id)sender {
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end

--- a/Source/Classes/MUMessageBubbleTableViewCell.m
+++ b/Source/Classes/MUMessageBubbleTableViewCell.m
@@ -61,24 +61,46 @@
 
 + (CGSize) textSizeForText:(NSString *)text {
     CGSize constraintSize = CGSizeMake(kBalloonWidth-(kBalloonMarginTailSide+kBalloonMarginNonTailSide), CGFLOAT_MAX);
-    return [text sizeWithFont:[UIFont systemFontOfSize:14.0f] constrainedToSize:constraintSize lineBreakMode:NSLineBreakByWordWrapping];
+    
+    CGRect rect = [text boundingRectWithSize:constraintSize
+                                  options:NSStringDrawingUsesLineFragmentOrigin
+                               attributes:@{ NSFontAttributeName : [UIFont systemFontOfSize:14.0f] }
+                                  context:nil];
+    return rect.size;
 }
 
 + (CGSize) headingSizeForText:(NSString *)text {
     CGSize constraintSize = CGSizeMake(kBalloonWidth-(kBalloonMarginTailSide+kBalloonMarginNonTailSide), CGFLOAT_MAX);
-    return [text sizeWithFont:[UIFont boldSystemFontOfSize:14.0f] constrainedToSize:constraintSize lineBreakMode:NSLineBreakByWordWrapping];
+    CGRect rect = [text boundingRectWithSize:constraintSize
+                                  options:NSStringDrawingUsesLineFragmentOrigin
+                               attributes:@{ NSFontAttributeName : [UIFont boldSystemFontOfSize:14.0f] }
+                                  context:nil];
+    return rect.size;
 }
 
 + (CGSize) timestampSizeForText:(NSString *)text {
     CGSize constraintSize = CGSizeMake(kBalloonWidth-(kBalloonMarginTailSide+kBalloonMarginNonTailSide), CGFLOAT_MAX);
-    return [text sizeWithFont:[UIFont italicSystemFontOfSize:11.0f] constrainedToSize:constraintSize lineBreakMode:NSLineBreakByTruncatingHead];
+
+    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+    paragraphStyle.lineBreakMode = NSLineBreakByTruncatingHead;
+
+    CGRect rect = [text boundingRectWithSize:constraintSize
+                                  options:NSStringDrawingUsesLineFragmentOrigin
+                                  attributes:@{ NSFontAttributeName : [UIFont italicSystemFontOfSize:11.0f], NSParagraphStyleAttributeName : paragraphStyle }
+                                  context:nil];
+    return rect.size;
 }
 
 + (CGSize) footerSizeForText:(NSString *)text {
     if (text == nil)
         return CGSizeZero;
     CGSize constraintSize = CGSizeMake(kBalloonWidth-(kBalloonMarginTailSide+kBalloonMarginNonTailSide), CGFLOAT_MAX);
-    return [text sizeWithFont:[UIFont italicSystemFontOfSize:11.0f] constrainedToSize:constraintSize lineBreakMode:NSLineBreakByWordWrapping];
+
+    CGRect rect = [text boundingRectWithSize:constraintSize
+                                  options:NSStringDrawingUsesLineFragmentOrigin
+                                  attributes:@{ NSFontAttributeName : [UIFont italicSystemFontOfSize:11.0f] }
+                                  context:nil];
+    return rect.size;
 }
 
 + (NSString *) stringForDate:(NSDate *)date {

--- a/Source/Classes/MUMessageBubbleTableViewCell.m
+++ b/Source/Classes/MUMessageBubbleTableViewCell.m
@@ -61,24 +61,24 @@
 
 + (CGSize) textSizeForText:(NSString *)text {
     CGSize constraintSize = CGSizeMake(kBalloonWidth-(kBalloonMarginTailSide+kBalloonMarginNonTailSide), CGFLOAT_MAX);
-    return [text sizeWithFont:[UIFont systemFontOfSize:14.0f] constrainedToSize:constraintSize lineBreakMode:UILineBreakModeWordWrap];
+    return [text sizeWithFont:[UIFont systemFontOfSize:14.0f] constrainedToSize:constraintSize lineBreakMode:NSLineBreakByWordWrapping];
 }
 
 + (CGSize) headingSizeForText:(NSString *)text {
     CGSize constraintSize = CGSizeMake(kBalloonWidth-(kBalloonMarginTailSide+kBalloonMarginNonTailSide), CGFLOAT_MAX);
-    return [text sizeWithFont:[UIFont boldSystemFontOfSize:14.0f] constrainedToSize:constraintSize lineBreakMode:UILineBreakModeWordWrap];
+    return [text sizeWithFont:[UIFont boldSystemFontOfSize:14.0f] constrainedToSize:constraintSize lineBreakMode:NSLineBreakByWordWrapping];
 }
 
 + (CGSize) timestampSizeForText:(NSString *)text {
     CGSize constraintSize = CGSizeMake(kBalloonWidth-(kBalloonMarginTailSide+kBalloonMarginNonTailSide), CGFLOAT_MAX);
-    return [text sizeWithFont:[UIFont italicSystemFontOfSize:11.0f] constrainedToSize:constraintSize lineBreakMode:UILineBreakModeHeadTruncation];
+    return [text sizeWithFont:[UIFont italicSystemFontOfSize:11.0f] constrainedToSize:constraintSize lineBreakMode:NSLineBreakByTruncatingHead];
 }
 
 + (CGSize) footerSizeForText:(NSString *)text {
     if (text == nil)
         return CGSizeZero;
     CGSize constraintSize = CGSizeMake(kBalloonWidth-(kBalloonMarginTailSide+kBalloonMarginNonTailSide), CGFLOAT_MAX);
-    return [text sizeWithFont:[UIFont italicSystemFontOfSize:11.0f] constrainedToSize:constraintSize lineBreakMode:UILineBreakModeWordWrap];
+    return [text sizeWithFont:[UIFont italicSystemFontOfSize:11.0f] constrainedToSize:constraintSize lineBreakMode:NSLineBreakByWordWrapping];
 }
 
 + (NSString *) stringForDate:(NSDate *)date {
@@ -227,10 +227,10 @@
                                    footerSize.width,
                                    footerSize.height);
     [[UIColor blackColor] set];
-    [footer drawInRect:footerRect withFont:[UIFont italicSystemFontOfSize:11.0f] lineBreakMode:UILineBreakModeWordWrap];
-    [heading drawInRect:headerRect withFont:[UIFont boldSystemFontOfSize:14.0f] lineBreakMode:UILineBreakModeWordWrap];
-    [dateStr drawInRect:timestampRect withFont:[UIFont italicSystemFontOfSize:11.0f] lineBreakMode:UILineBreakModeHeadTruncation];
-    [text drawInRect:textRect withFont:[UIFont systemFontOfSize:14.0f] lineBreakMode:UILineBreakModeWordWrap];
+    [footer drawInRect:footerRect withFont:[UIFont italicSystemFontOfSize:11.0f] lineBreakMode:NSLineBreakByWordWrapping];
+    [heading drawInRect:headerRect withFont:[UIFont boldSystemFontOfSize:14.0f] lineBreakMode:NSLineBreakByWordWrapping];
+    [dateStr drawInRect:timestampRect withFont:[UIFont italicSystemFontOfSize:11.0f] lineBreakMode:NSLineBreakByTruncatingHead];
+    [text drawInRect:textRect withFont:[UIFont systemFontOfSize:14.0f] lineBreakMode:NSLineBreakByWordWrapping];
 }
 
 - (CGRect) selectionRect {    

--- a/Source/Classes/MUMessageRecipientViewController.m
+++ b/Source/Classes/MUMessageRecipientViewController.m
@@ -234,13 +234,13 @@
     }
 
     [self.tableView deselectRowAtIndexPath:indexPath animated:YES];
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - Actions
 
 - (void) cancelClicked:(id)sender {
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - MKServerModel delegate

--- a/Source/Classes/MUMessagesViewController.m
+++ b/Source/Classes/MUMessagesViewController.m
@@ -479,7 +479,7 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
     [recipientViewController setDelegate:self];
     UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:recipientViewController];
 
-    [self presentModalViewController:navCtrl animated:YES];
+    [self presentViewController:navCtrl animated:YES completion:nil];
 }
 
 #pragma mark - MUMessageBubbleTableViewCellDelegate

--- a/Source/Classes/MUMessagesViewController.m
+++ b/Source/Classes/MUMessagesViewController.m
@@ -77,7 +77,7 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
         } else {
             _str = [str copy];
         }
-        CGSize size = [_str sizeWithFont:[UIFont boldSystemFontOfSize:14.0f]];
+        CGSize size = [_str sizeWithAttributes:@{ NSFontAttributeName : [UIFont boldSystemFontOfSize:14.0f] }];
         if (MUGetOperatingSystemVersion() < MUMBLE_OS_IOS_7) {
             size.width += 6*2;
         }

--- a/Source/Classes/MUNotificationController.m
+++ b/Source/Classes/MUNotificationController.m
@@ -83,7 +83,7 @@
     [_notificationQueue removeObjectAtIndex:0];
     lbl.textColor = [UIColor whiteColor];
     lbl.backgroundColor = [UIColor clearColor];
-    lbl.textAlignment = UITextAlignmentCenter;
+    lbl.textAlignment = NSTextAlignmentCenter;
     [container addSubview:lbl];
     
     [[[UIApplication sharedApplication] keyWindow] addSubview:container];

--- a/Source/Classes/MUOperatingSystem.h
+++ b/Source/Classes/MUOperatingSystem.h
@@ -10,4 +10,4 @@ typedef NS_ENUM(NSInteger, MUOperatingSystemVersion) {
     MUMBLE_OS_IOS_7,
 };
 
-MUOperatingSystemVersion MUGetOperatingSystemVersion();
+MUOperatingSystemVersion MUGetOperatingSystemVersion(void);

--- a/Source/Classes/MUOperatingSystem.m
+++ b/Source/Classes/MUOperatingSystem.m
@@ -4,7 +4,7 @@
 
 #import "MUOperatingSystem.h"
 
-MUOperatingSystemVersion MUGetOperatingSystemVersion() {
+MUOperatingSystemVersion MUGetOperatingSystemVersion(void) {
     NSString *iOSVersion = [[UIDevice currentDevice] systemVersion];
     if (iOSVersion) {
         NSArray *iOSVersionComponents = [iOSVersion componentsSeparatedByString:@"."];

--- a/Source/Classes/MUPreferencesViewController.m
+++ b/Source/Classes/MUPreferencesViewController.m
@@ -32,7 +32,7 @@
 
 - (id) init {
     if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
-        [self setContentSizeForViewInPopover:CGSizeMake(320, 480)];
+        self.preferredContentSize = CGSizeMake(320, 480);
     }
     return self;
 }

--- a/Source/Classes/MURemoteControlServer.m
+++ b/Source/Classes/MURemoteControlServer.m
@@ -20,7 +20,7 @@
 @end
 
 static void *serverThread(void *udata) {
-    int sock = (int) udata;
+    int sock = (int) (long) udata;
     unsigned char action;
     
     int val = 1;

--- a/Source/Classes/MUServerButton.m
+++ b/Source/Classes/MUServerButton.m
@@ -173,7 +173,13 @@
     CGContextSaveGState(context);
     CGContextSetShadowWithColor(context, textShadowOffset, textShadowBlurRadius, textShadow.CGColor);
     [[UIColor whiteColor] setFill];
-    [titleTextContent drawInRect: titleTextRect withFont: [UIFont systemFontOfSize: 32] lineBreakMode: NSLineBreakByWordWrapping alignment: NSTextAlignmentCenter];
+    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+    paragraphStyle.lineBreakMode = NSLineBreakByWordWrapping;
+    paragraphStyle.alignment = NSTextAlignmentCenter;
+    [titleTextContent drawInRect:titleTextRect withAttributes:@{
+        NSFontAttributeName : [UIFont systemFontOfSize: 32],
+        NSParagraphStyleAttributeName : paragraphStyle
+    }];
     CGContextRestoreGState(context);
     
     
@@ -183,7 +189,13 @@
     CGContextSaveGState(context);
     CGContextSetShadowWithColor(context, textShadowOffset, textShadowBlurRadius, textShadow.CGColor);
     [[UIColor whiteColor] setFill];
-    [pingTextContent drawInRect: pingTextRect withFont: [UIFont systemFontOfSize: [UIFont buttonFontSize]] lineBreakMode: NSLineBreakByWordWrapping alignment: NSTextAlignmentLeft];
+    paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+    paragraphStyle.lineBreakMode = NSLineBreakByWordWrapping;
+    paragraphStyle.alignment = NSTextAlignmentLeft;
+    [pingTextContent drawInRect:pingTextRect withAttributes:@{
+        NSFontAttributeName : [UIFont systemFontOfSize: [UIFont buttonFontSize]],
+        NSParagraphStyleAttributeName : paragraphStyle
+    }];
     CGContextRestoreGState(context);
     
     
@@ -193,7 +205,13 @@
     CGContextSaveGState(context);
     CGContextSetShadowWithColor(context, textShadowOffset, textShadowBlurRadius, textShadow.CGColor);
     [[UIColor whiteColor] setFill];
-    [userTextContent drawInRect: userTextRect withFont: [UIFont systemFontOfSize: [UIFont buttonFontSize]] lineBreakMode: NSLineBreakByWordWrapping alignment: NSTextAlignmentRight];
+    paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+    paragraphStyle.lineBreakMode = NSLineBreakByWordWrapping;
+    paragraphStyle.alignment = NSTextAlignmentRight;
+    [userTextContent drawInRect:userTextRect withAttributes:@{
+        NSFontAttributeName : [UIFont systemFontOfSize: [UIFont buttonFontSize]],
+        NSParagraphStyleAttributeName : paragraphStyle
+    }];
     CGContextRestoreGState(context);
     
     
@@ -203,7 +221,13 @@
     CGContextSaveGState(context);
     CGContextSetShadowWithColor(context, textShadowOffset, textShadowBlurRadius, textShadow.CGColor);
     [[UIColor whiteColor] setFill];
-    [addressTextContent drawInRect: addressTextRect withFont: [UIFont systemFontOfSize: 13] lineBreakMode: NSLineBreakByWordWrapping alignment: NSTextAlignmentCenter];
+    paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+    paragraphStyle.lineBreakMode = NSLineBreakByWordWrapping;
+    paragraphStyle.alignment = NSTextAlignmentCenter;
+    [addressTextContent drawInRect:addressTextRect withAttributes:@{
+        NSFontAttributeName : [UIFont systemFontOfSize: [UIFont buttonFontSize]],
+        NSParagraphStyleAttributeName : paragraphStyle
+    }];
     CGContextRestoreGState(context);
     
     
@@ -213,7 +237,13 @@
     CGContextSaveGState(context);
     CGContextSetShadowWithColor(context, textShadowOffset, textShadowBlurRadius, textShadow.CGColor);
     [[UIColor whiteColor] setFill];
-    [usernameTextContent drawInRect: usernameTextRect withFont: [UIFont systemFontOfSize: 13] lineBreakMode: NSLineBreakByWordWrapping alignment: NSTextAlignmentCenter];
+    paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+    paragraphStyle.lineBreakMode = NSLineBreakByWordWrapping;
+    paragraphStyle.alignment = NSTextAlignmentCenter;
+    [usernameTextContent drawInRect:usernameTextRect withAttributes:@{
+        NSFontAttributeName : [UIFont systemFontOfSize: 13],
+        NSParagraphStyleAttributeName : paragraphStyle
+    }];
     CGContextRestoreGState(context);
     
     

--- a/Source/Classes/MUServerButton.m
+++ b/Source/Classes/MUServerButton.m
@@ -173,7 +173,7 @@
     CGContextSaveGState(context);
     CGContextSetShadowWithColor(context, textShadowOffset, textShadowBlurRadius, textShadow.CGColor);
     [[UIColor whiteColor] setFill];
-    [titleTextContent drawInRect: titleTextRect withFont: [UIFont systemFontOfSize: 32] lineBreakMode: UILineBreakModeWordWrap alignment: UITextAlignmentCenter];
+    [titleTextContent drawInRect: titleTextRect withFont: [UIFont systemFontOfSize: 32] lineBreakMode: NSLineBreakByWordWrapping alignment: NSTextAlignmentCenter];
     CGContextRestoreGState(context);
     
     
@@ -183,7 +183,7 @@
     CGContextSaveGState(context);
     CGContextSetShadowWithColor(context, textShadowOffset, textShadowBlurRadius, textShadow.CGColor);
     [[UIColor whiteColor] setFill];
-    [pingTextContent drawInRect: pingTextRect withFont: [UIFont systemFontOfSize: [UIFont buttonFontSize]] lineBreakMode: UILineBreakModeWordWrap alignment: UITextAlignmentLeft];
+    [pingTextContent drawInRect: pingTextRect withFont: [UIFont systemFontOfSize: [UIFont buttonFontSize]] lineBreakMode: NSLineBreakByWordWrapping alignment: NSTextAlignmentLeft];
     CGContextRestoreGState(context);
     
     
@@ -193,7 +193,7 @@
     CGContextSaveGState(context);
     CGContextSetShadowWithColor(context, textShadowOffset, textShadowBlurRadius, textShadow.CGColor);
     [[UIColor whiteColor] setFill];
-    [userTextContent drawInRect: userTextRect withFont: [UIFont systemFontOfSize: [UIFont buttonFontSize]] lineBreakMode: UILineBreakModeWordWrap alignment: UITextAlignmentRight];
+    [userTextContent drawInRect: userTextRect withFont: [UIFont systemFontOfSize: [UIFont buttonFontSize]] lineBreakMode: NSLineBreakByWordWrapping alignment: NSTextAlignmentRight];
     CGContextRestoreGState(context);
     
     
@@ -203,7 +203,7 @@
     CGContextSaveGState(context);
     CGContextSetShadowWithColor(context, textShadowOffset, textShadowBlurRadius, textShadow.CGColor);
     [[UIColor whiteColor] setFill];
-    [addressTextContent drawInRect: addressTextRect withFont: [UIFont systemFontOfSize: 13] lineBreakMode: UILineBreakModeWordWrap alignment: UITextAlignmentCenter];
+    [addressTextContent drawInRect: addressTextRect withFont: [UIFont systemFontOfSize: 13] lineBreakMode: NSLineBreakByWordWrapping alignment: NSTextAlignmentCenter];
     CGContextRestoreGState(context);
     
     
@@ -213,7 +213,7 @@
     CGContextSaveGState(context);
     CGContextSetShadowWithColor(context, textShadowOffset, textShadowBlurRadius, textShadow.CGColor);
     [[UIColor whiteColor] setFill];
-    [usernameTextContent drawInRect: usernameTextRect withFont: [UIFont systemFontOfSize: 13] lineBreakMode: UILineBreakModeWordWrap alignment: UITextAlignmentCenter];
+    [usernameTextContent drawInRect: usernameTextRect withFont: [UIFont systemFontOfSize: 13] lineBreakMode: NSLineBreakByWordWrapping alignment: NSTextAlignmentCenter];
     CGContextRestoreGState(context);
     
     

--- a/Source/Classes/MUServerCell.m
+++ b/Source/Classes/MUServerCell.m
@@ -98,10 +98,14 @@
 
     CGContextSetTextDrawingMode(ctx, kCGTextFill);
     CGContextSetFillColorWithColor(ctx, [UIColor whiteColor].CGColor);
-    [pingStr drawInRect:CGRectMake(0.0, 0.0, 32.0, 32.0)
-               withFont:[UIFont boldSystemFontOfSize:12]
-          lineBreakMode:NSLineBreakByTruncatingTail
-              alignment:NSTextAlignmentCenter];
+    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+    paragraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
+    paragraphStyle.alignment = NSTextAlignmentCenter;
+    [pingStr drawInRect:CGRectMake(0.0, 0.0, 32.0, 32.0) withAttributes:@{
+        NSFontAttributeName : [UIFont boldSystemFontOfSize: 12],
+        NSParagraphStyleAttributeName : paragraphStyle,
+        NSForegroundColorAttributeName : [UIColor whiteColor]
+    }];
 
     if (!isFull) {
         // Non-full servers get the mild iOS blue color
@@ -116,10 +120,14 @@
     CGContextSetTextDrawingMode(ctx, kCGTextFill);
     CGContextSetFillColorWithColor(ctx, [UIColor whiteColor].CGColor);
     NSString *usersStr = [NSString stringWithFormat:NSLocalizedString(@"%lu\nppl", @"user count"), (unsigned long)userCount];
-    [usersStr drawInRect:CGRectMake(34.0, 0.0, 32.0, 32.0)
-                withFont:[UIFont boldSystemFontOfSize:12]
-           lineBreakMode:NSLineBreakByTruncatingTail
-               alignment:NSTextAlignmentCenter];
+    paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+    paragraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
+    paragraphStyle.alignment = NSTextAlignmentCenter;
+    [usersStr drawInRect:CGRectMake(34.0, 0.0, 32.0, 32.0) withAttributes:@{
+        NSFontAttributeName : [UIFont boldSystemFontOfSize: 12],
+        NSParagraphStyleAttributeName : paragraphStyle,
+        NSForegroundColorAttributeName : [UIColor whiteColor]
+    }];
     
     img = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();

--- a/Source/Classes/MUServerCell.m
+++ b/Source/Classes/MUServerCell.m
@@ -100,8 +100,8 @@
     CGContextSetFillColorWithColor(ctx, [UIColor whiteColor].CGColor);
     [pingStr drawInRect:CGRectMake(0.0, 0.0, 32.0, 32.0)
                withFont:[UIFont boldSystemFontOfSize:12]
-          lineBreakMode:UILineBreakModeTailTruncation
-              alignment:UITextAlignmentCenter];
+          lineBreakMode:NSLineBreakByTruncatingTail
+              alignment:NSTextAlignmentCenter];
 
     if (!isFull) {
         // Non-full servers get the mild iOS blue color
@@ -118,8 +118,8 @@
     NSString *usersStr = [NSString stringWithFormat:NSLocalizedString(@"%lu\nppl", @"user count"), (unsigned long)userCount];
     [usersStr drawInRect:CGRectMake(34.0, 0.0, 32.0, 32.0)
                 withFont:[UIFont boldSystemFontOfSize:12]
-           lineBreakMode:UILineBreakModeTailTruncation
-               alignment:UITextAlignmentCenter];
+           lineBreakMode:NSLineBreakByTruncatingTail
+               alignment:NSTextAlignmentCenter];
     
     img = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();

--- a/Source/Classes/MUServerCertificateTrustViewController.m
+++ b/Source/Classes/MUServerCertificateTrustViewController.m
@@ -32,7 +32,7 @@
     [super viewWillAppear:animated];
 
     UIBarButtonItem *dismissButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Dismiss", nil)
-                                                                      style:UIBarButtonItemStyleBordered
+                                                                      style:UIBarButtonItemStylePlain
                                                                      target:self
                                                                      action:@selector(dismissClicked:)];
     self.navigationItem.leftBarButtonItem = dismissButton;

--- a/Source/Classes/MUServerCertificateTrustViewController.m
+++ b/Source/Classes/MUServerCertificateTrustViewController.m
@@ -42,7 +42,7 @@
 #pragma mark Actions
 
 - (void) dismissClicked:(id)sender {
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:nil];
     [_delegate serverCertificateTrustViewControllerDidDismiss:self];
 }
 

--- a/Source/Classes/MUServerRootViewController.m
+++ b/Source/Classes/MUServerRootViewController.m
@@ -355,7 +355,7 @@
 }
 
 - (void) childDoneButton:(id)sender {
-    [[self modalViewController] dismissViewControllerAnimated:YES completion:nil];
+    [[self presentedViewController] dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void) modeSwitchButtonReleased:(id)sender {

--- a/Source/Classes/MUServerRootViewController.m
+++ b/Source/Classes/MUServerRootViewController.m
@@ -98,7 +98,7 @@
     
     _serverView.navigationItem.titleView = _segmentedControl;
     
-    _menuButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"MumbleMenuButton"] style:UIBarButtonItemStyleBordered target:self action:@selector(actionButtonClicked:)];
+    _menuButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"MumbleMenuButton"] style:UIBarButtonItemStylePlain target:self action:@selector(actionButtonClicked:)];
     _serverView.navigationItem.rightBarButtonItem = _menuButton;
     
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];

--- a/Source/Classes/MUServerRootViewController.m
+++ b/Source/Classes/MUServerRootViewController.m
@@ -92,7 +92,6 @@
     
     _segmentIndex = 0;
     
-    _segmentedControl.segmentedControlStyle = UISegmentedControlStyleBar;
     _segmentedControl.selectedSegmentIndex = _segmentIndex;
     [_segmentedControl addTarget:self action:@selector(segmentChanged:) forControlEvents:UIControlEventValueChanged];
     

--- a/Source/Classes/MUServerRootViewController.m
+++ b/Source/Classes/MUServerRootViewController.m
@@ -128,10 +128,6 @@
     self.toolbar.barStyle = UIBarStyleBlackOpaque;
 }
 
-- (void) viewDidUnload {
-    [super viewDidUnload];
-}
-
 - (void) viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
 }

--- a/Source/Classes/MUServerRootViewController.m
+++ b/Source/Classes/MUServerRootViewController.m
@@ -360,7 +360,7 @@
 }
 
 - (void) childDoneButton:(id)sender {
-    [[self modalViewController] dismissModalViewControllerAnimated:YES];
+    [[self modalViewController] dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void) modeSwitchButtonReleased:(id)sender {
@@ -388,17 +388,17 @@
     } else if (buttonIndex == _mixerDebugIndex) {
         MUAudioMixerDebugViewController *audioMixerDebugViewController = [[MUAudioMixerDebugViewController alloc] init];
         UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:audioMixerDebugViewController];
-        [self presentModalViewController:navCtrl animated:YES];
+        [self presentViewController:navCtrl animated:YES completion:nil];
     } else if (buttonIndex == _accessTokensIndex) {
         MUAccessTokenViewController *tokenViewController = [[MUAccessTokenViewController alloc] initWithServerModel:_model];
         UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:tokenViewController];
-        [self presentModalViewController:navCtrl animated:YES];
+        [self presentViewController:navCtrl animated:YES completion:nil];
     } else if (buttonIndex == _certificatesIndex) { // Certificates
         MUCertificateViewController *certView = [[MUCertificateViewController alloc] initWithCertificates:[_model serverCertificates]];
         UINavigationController *navCtrl = [[UINavigationController alloc] initWithRootViewController:certView];
         UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(childDoneButton:)];
         certView.navigationItem.leftBarButtonItem = doneButton;
-        [self presentModalViewController:navCtrl animated:YES];
+        [self presentViewController:navCtrl animated:YES completion:nil];
     } else if (buttonIndex == _selfRegisterIndex) { // Self-Register
         NSString *title = NSLocalizedString(@"User Registration", nil);
         NSString *msg = [NSString stringWithFormat:

--- a/Source/Classes/MUTableViewHeaderLabel.m
+++ b/Source/Classes/MUTableViewHeaderLabel.m
@@ -18,7 +18,7 @@
             self.shadowOffset = CGSizeMake(1.5f, 1.5f);
         }
         self.backgroundColor = [UIColor clearColor];
-        self.textAlignment = UITextAlignmentCenter;
+        self.textAlignment = NSTextAlignmentCenter;
     }
     return self;
 }

--- a/Source/Classes/MUVoiceActivitySetupViewController.m
+++ b/Source/Classes/MUVoiceActivitySetupViewController.m
@@ -14,7 +14,7 @@
 
 - (id) init {
     if ((self = [super initWithStyle:UITableViewStyleGrouped])) {
-        self.contentSizeForViewInPopover = CGSizeMake(320, 480);
+        self.preferredContentSize = CGSizeMake(320, 480);
     }
     return self;
 }

--- a/Source/Classes/MUWelcomeScreenPad.m
+++ b/Source/Classes/MUWelcomeScreenPad.m
@@ -161,7 +161,7 @@
         MULegalViewController *legalView = [[MULegalViewController alloc] init];
         UINavigationController *navController = [[UINavigationController alloc] init];
         [navController pushViewController:legalView animated:NO];
-        [[self navigationController] presentModalViewController:navController animated:YES];
+        [[self navigationController] presentViewController:navController animated:YES completion:nil];
     } else if (buttonIndex == 3) {
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"mailto:support@mumbleapp.com"]];
     }

--- a/Source/Classes/MUWelcomeScreenPad.m
+++ b/Source/Classes/MUWelcomeScreenPad.m
@@ -82,10 +82,10 @@
     
     self.navigationController.navigationBar.barStyle = UIBarStyleBlackOpaque;
     
-    UIBarButtonItem *aboutBtn = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"About", nil) style:UIBarButtonItemStyleBordered target:self action:@selector(aboutButtonClicked:)];
+    UIBarButtonItem *aboutBtn = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"About", nil) style:UIBarButtonItemStylePlain target:self action:@selector(aboutButtonClicked:)];
     self.navigationItem.rightBarButtonItem = aboutBtn;
     
-    UIBarButtonItem *prefsBtn = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Preferences", nil) style:UIBarButtonItemStyleBordered target:self action:@selector(prefsButtonClicked:)];
+    UIBarButtonItem *prefsBtn = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Preferences", nil) style:UIBarButtonItemStylePlain target:self action:@selector(prefsButtonClicked:)];
     self.navigationItem.leftBarButtonItem = prefsBtn;
     
     [_tableView deselectRowAtIndexPath:[_tableView indexPathForSelectedRow] animated:animated];

--- a/Source/Classes/MUWelcomeScreenPhone.m
+++ b/Source/Classes/MUWelcomeScreenPhone.m
@@ -192,7 +192,7 @@
         MULegalViewController *legalView = [[MULegalViewController alloc] init];
         UINavigationController *navController = [[UINavigationController alloc] init];
         [navController pushViewController:legalView animated:NO];
-        [[self navigationController] presentModalViewController:navController animated:YES];
+        [[self navigationController] presentViewController:navController animated:YES completion:nil];
     } else if (buttonIndex == 3) {
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"mailto:support@mumbleapp.com"]];
     }

--- a/Source/Classes/MUWelcomeScreenPhone.m
+++ b/Source/Classes/MUWelcomeScreenPhone.m
@@ -61,13 +61,13 @@
     
 #if MUMBLE_LAUNCH_IMAGE_CREATION != 1
     UIBarButtonItem *about = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"About", nil)
-                                                              style:UIBarButtonItemStyleBordered
+                                                              style:UIBarButtonItemStylePlain
                                                              target:self
                                                              action:@selector(aboutClicked:)];
     [self.navigationItem setRightBarButtonItem:about];
     
     UIBarButtonItem *prefs = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Preferences", nil)
-                                                              style:UIBarButtonItemStyleBordered
+                                                              style:UIBarButtonItemStylePlain
                                                              target:self
                                                              action:@selector(prefsClicked:)];
     [self.navigationItem setLeftBarButtonItem:prefs];


### PR DESCRIPTION
With the updated build target, there's a lot of deprecations to address.

For starters, I went for the easy ones - simple with straightforward replacements, like renamed types/constants or APIs that just slightly changed the way they're used (e.g. attributes vs specific named arguments).
I also fixed a few random lints that came up.

This gets down from 334 to 182 issues reported on a fresh build.

A lot of what remains is UIAlertController, which replaces a few distinct APIs for showing popup dialogs (e.g. Ok/Cancel type stuff). Replacing that is quite manual and laborious, so I skipped on that for now.