### PR TITLE
Info.plist: opt out of dark mode

### DIFF
--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
The mumble app currently does not work very well with iOS's dark mode, for which support is automatically enabled on newer SDKs [1]. Force "Light mode" for now until we can address it properly.

Related to https://github.com/mumble-voip/mumble-iphoneos/issues/148, but does not fix it.

[1] https://developer.apple.com/documentation/uikit/choosing-a-specific-interface-style-for-your-ios-app?language=objc#Opt-Out-of-Dark-Mode-Entirely