### PR TITLE
MUConnectionController: fix transition from MUServerRootViewController

### DIFF
--- a/Source/Classes/MUConnectionController.m
+++ b/Source/Classes/MUConnectionController.m
@@ -363,15 +363,7 @@ NSString *MUConnectionClosedNotification = @"MUConnectionClosedNotification";
     _hostname = nil;
     _password = nil;
 
-    if ([[UIDevice currentDevice] userInterfaceIdiom] != UIUserInterfaceIdiomPad) {
-        if (MUGetOperatingSystemVersion() >= MUMBLE_OS_IOS_7) {
-            [_serverRoot setTransitioningDelegate:_transitioningDelegate];
-        } else {
-            [_serverRoot setModalTransitionStyle:UIModalTransitionStyleFlipHorizontal];
-        }
-    }
-
-    [_parentViewController presentViewController:_serverRoot animated:YES completion:nil];
+    [[_parentViewController navigationController] presentViewController:_serverRoot animated:YES completion:nil];
     _parentViewController = nil;
 }
 


### PR DESCRIPTION
Previously, this came back to an empty screen when disconnecting, effectively softlocking the app.

This changes the transition to use a "popover" style instead of the previous "flip" style. The "flip" transition kind of fell out of fashion anyway, so I don't think it's that much of a loss.

Fixes #146