### PR TITLE
Replace UIAlertView/UIActionSheet with UIAlertController

### DIFF
--- a/Source/Classes/MUCertificateDiskImportViewController.h
+++ b/Source/Classes/MUCertificateDiskImportViewController.h
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-@interface MUCertificateDiskImportViewController : UITableViewController <UIAlertViewDelegate, UITextFieldDelegate>
+@interface MUCertificateDiskImportViewController : UITableViewController <UITextFieldDelegate>
 
 - (id) init;
 

--- a/Source/Classes/MUCertificatePreferencesViewController.m
+++ b/Source/Classes/MUCertificatePreferencesViewController.m
@@ -13,7 +13,7 @@
 
 #import <MumbleKit/MKCertificate.h>
 
-@interface MUCertificatePreferencesViewController () <UIActionSheetDelegate> {
+@interface MUCertificatePreferencesViewController () {
     NSMutableArray   *_certificateItems;
     BOOL             _picker;
     NSUInteger       _selectedIndex;
@@ -182,38 +182,43 @@
 - (void) addButtonClicked:(UIBarButtonItem *)addButton {
     NSString *showAllCerts = NSLocalizedString(@"Show All Certificates", nil);
     NSString *showIdentities = NSLocalizedString(@"Show Identities Only", nil);
-    UIActionSheet *sheet = [[UIActionSheet alloc] initWithTitle:nil
-                                                       delegate:self
-                                              cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
-                                         destructiveButtonTitle:nil
-                                              otherButtonTitles:NSLocalizedString(@"Generate New Certificate", nil),
-                                                                _showAll ? showIdentities : showAllCerts,
-                                                                NSLocalizedString(@"Import From iTunes", nil),
-                            nil];
-    [sheet setActionSheetStyle:UIActionSheetStyleBlackOpaque];
-    [sheet showInView:self.view];
-}
-
-#pragma mark -
-#pragma mark UIActionSheet delegate
-
-- (void) actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)idx {
-    if (idx == 0) { // Generate New Certificate
+    
+    UIAlertController *sheetCtrl = [UIAlertController alertControllerWithTitle:nil
+                                                                       message:nil
+                                                                preferredStyle:UIAlertControllerStyleActionSheet];
+    
+    [sheetCtrl addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
+                                                   style:UIAlertActionStyleCancel
+                                                 handler:nil]];
+    
+    [sheetCtrl addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"Generate New Certificate", nil)
+                                                   style:UIAlertActionStyleDefault
+                                                 handler:^(UIAlertAction * _Nonnull action) {
         UINavigationController *navCtrl = [[UINavigationController alloc] init];
         navCtrl.modalPresentationStyle = UIModalPresentationCurrentContext;
         MUCertificateCreationView *certGen = [[MUCertificateCreationView alloc] init];
         [navCtrl pushViewController:certGen animated:NO];
         [[self navigationController] presentViewController:navCtrl animated:YES completion:nil];
-    } else if (idx == 1) { // Show All Certificates; Show Identities Only
-        _showAll = !_showAll;
-        [[NSUserDefaults standardUserDefaults] setBool:_showAll forKey:@"CertificatesShowIntermediates"];
+    }]];
+    
+    [sheetCtrl addAction: [UIAlertAction actionWithTitle:_showAll ? showIdentities : showAllCerts
+                                                   style:UIAlertActionStyleDefault
+                                                 handler:^(UIAlertAction * _Nonnull action) {
+        self->_showAll = !self->_showAll;
+        [[NSUserDefaults standardUserDefaults] setBool:self->_showAll forKey:@"CertificatesShowIntermediates"];
         [self fetchCertificates];
         [self.tableView reloadData];
-    } else if (idx == 2) { // Import From iTunes
+    }]];
+    
+    [sheetCtrl addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"Import From iTunes", nil)
+                                                   style:UIAlertActionStyleDefault
+                                                 handler:^(UIAlertAction * _Nonnull action) {
         MUCertificateDiskImportViewController *diskImportViewController = [[MUCertificateDiskImportViewController alloc] init];
         UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:diskImportViewController];
         [[self navigationController] presentViewController:navController animated:YES completion:nil];
-    }
+    }]];
+    
+    [self presentViewController:sheetCtrl animated:YES completion:nil];
 }
 
 #pragma mark -

--- a/Source/Classes/MUImageViewController.m
+++ b/Source/Classes/MUImageViewController.m
@@ -6,7 +6,7 @@
 #import "MUOperatingSystem.h"
 #import "MUColor.h"
 
-@interface MUImageViewController () <UIScrollViewDelegate, UIActionSheetDelegate> {
+@interface MUImageViewController () <UIScrollViewDelegate> {
     NSArray        *_images;
     NSArray        *_imageViews;
     UIScrollView   *_scrollView;
@@ -109,35 +109,35 @@
     return nil;
 }
 
-#pragma mark - UIActionSheetDelegate
-
-- (void) actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex {
-    if (buttonIndex == 0) {
-        UIImageWriteToSavedPhotosAlbum([_images objectAtIndex:_curPage], self, @selector(image:didFinishSavingWithError:contextInfo:), NULL);
-    }
-}
-
 #pragma mark - Actions
 
 - (void) image:(UIImage *)img didFinishSavingWithError:(NSError *)err contextInfo:(void *)userInfo {
     if (err != nil) {
-        UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Unable to save image", nil)
-                                                            message:[err description]
-                                                           delegate:nil 
-                                                   cancelButtonTitle:NSLocalizedString(@"OK", nil)
-                                                  otherButtonTitles:nil];
-        [alertView show];
+        UIAlertController* alertCtrl = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Unable to save image", nil)
+                                                                           message:[err description]
+                                                                    preferredStyle:UIAlertControllerStyleAlert];
+        [alertCtrl addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                       style:UIAlertActionStyleCancel
+                                                     handler:nil]];
+        
+        [self presentViewController:alertCtrl animated:YES completion:nil];
     }
 }
 
 - (void) actionClicked:(id)sender {
-    UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:NSLocalizedString(@"Export Image", nil)
-                                                             delegate:self
-                                                    cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
-                                               destructiveButtonTitle:nil
-                                                    otherButtonTitles:NSLocalizedString(@"Export to Photos", nil), nil];
-    [actionSheet setActionSheetStyle:UIActionSheetStyleBlackOpaque];
-    [actionSheet showFromBarButtonItem:sender animated:YES];
+    UIAlertController* alertCtrl = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Export Image", nil)
+                                                                       message:nil
+                                                                preferredStyle:UIAlertControllerStyleActionSheet];
+    [alertCtrl addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
+                                                   style:UIAlertActionStyleCancel
+                                                 handler:nil]];
+    [alertCtrl addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"Export to Photos", nil)
+                                                   style:UIAlertActionStyleDefault
+                                                 handler:^(UIAlertAction * _Nonnull action) {
+        UIImageWriteToSavedPhotosAlbum([self->_images objectAtIndex:self->_curPage], self, @selector(image:didFinishSavingWithError:contextInfo:), NULL);
+    }]];
+    
+    [self presentViewController:alertCtrl animated:YES completion:nil];
 }
 
 @end

--- a/Source/Classes/MUVoiceActivitySetupViewController.m
+++ b/Source/Classes/MUVoiceActivitySetupViewController.m
@@ -199,12 +199,15 @@
                                           @"3. When not speaking, the bar should stay inside the red area.",
                                                 @"Help text for Voice Activity");
         
-        UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title
-                                                            message:msg
-                                                           delegate:self
-                                                  cancelButtonTitle:NSLocalizedString(@"OK", nil)
-                                                  otherButtonTitles:nil];
-        [alertView show];
+        UIAlertController *alertCtrl = [UIAlertController alertControllerWithTitle:title
+                                                                           message:msg
+                                                                    preferredStyle:UIAlertControllerStyleAlert];
+        
+        [alertCtrl addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                       style:UIAlertActionStyleCancel
+                                                     handler: nil]];
+        
+        [self presentViewController:alertCtrl animated:YES completion:nil];
     }
 }
 

--- a/Source/Classes/MUWelcomeScreenPad.m
+++ b/Source/Classes/MUWelcomeScreenPad.m
@@ -151,22 +151,6 @@
     }
 }
 
-#pragma mark -
-#pragma mark About Dialog
-
-- (void) alertView:(UIAlertView *)alert didDismissWithButtonIndex:(NSInteger)buttonIndex {
-    if (buttonIndex == 1) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.mumbleapp.com/"]];
-    } else if (buttonIndex == 2) {
-        MULegalViewController *legalView = [[MULegalViewController alloc] init];
-        UINavigationController *navController = [[UINavigationController alloc] init];
-        [navController pushViewController:legalView animated:NO];
-        [[self navigationController] presentViewController:navController animated:YES completion:nil];
-    } else if (buttonIndex == 3) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"mailto:support@mumbleapp.com"]];
-    }
-}
-
 #pragma mark - Actions
 
 - (void) aboutButtonClicked:(id)sender {
@@ -180,12 +164,31 @@
 #endif
     NSString *aboutMessage = NSLocalizedString(@"Low latency, high quality voice chat", nil);
     
-    UIAlertView *aboutView = [[UIAlertView alloc] initWithTitle:aboutTitle message:aboutMessage delegate:self
-                                              cancelButtonTitle:NSLocalizedString(@"OK", nil)
-                                              otherButtonTitles:NSLocalizedString(@"Website", nil),
-                              NSLocalizedString(@"Legal", nil),
-                              NSLocalizedString(@"Support", nil), nil];
-    [aboutView show];
+    UIAlertController* aboutAlert = [UIAlertController alertControllerWithTitle:aboutTitle message:aboutMessage preferredStyle:UIAlertControllerStyleAlert];
+    
+    [aboutAlert addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                    style:UIAlertActionStyleCancel
+                                                  handler:nil]];
+    [aboutAlert addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"Website", nil)
+                                                    style:UIAlertActionStyleDefault
+                                                  handler:^(UIAlertAction * _Nonnull action) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.mumbleapp.com/"]];
+    }]];
+    [aboutAlert addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"Legal", nil)
+                                                    style:UIAlertActionStyleDefault
+                                                  handler:^(UIAlertAction * _Nonnull action) {
+        MULegalViewController *legalView = [[MULegalViewController alloc] init];
+        UINavigationController *navController = [[UINavigationController alloc] init];
+        [navController pushViewController:legalView animated:NO];
+        [[self navigationController] presentViewController:navController animated:YES completion:nil];
+    }]];
+    [aboutAlert addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"Support", nil)
+                                                    style:UIAlertActionStyleDefault
+                                                  handler:^(UIAlertAction * _Nonnull action) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"mailto:support@mumbleapp.com"]];
+    }]];
+    
+    [self presentViewController:aboutAlert animated:YES completion:nil];
 }
 
 - (void) prefsButtonClicked:(id)sender {

--- a/Source/Classes/MUWelcomeScreenPhone.m
+++ b/Source/Classes/MUWelcomeScreenPhone.m
@@ -16,7 +16,6 @@
 #import "MUBackgroundView.h"
 
 @interface MUWelcomeScreenPhone () {
-    UIAlertView  *_aboutView;
     NSInteger    _aboutWebsiteButton;
     NSInteger    _aboutContribButton;
     NSInteger    _aboutLegalButton;
@@ -169,33 +168,36 @@
 #endif
     NSString *aboutMessage = NSLocalizedString(@"Low latency, high quality voice chat", nil);
     
-    UIAlertView *aboutView = [[UIAlertView alloc] initWithTitle:aboutTitle message:aboutMessage delegate:self
-                                              cancelButtonTitle:NSLocalizedString(@"OK", nil)
-                                              otherButtonTitles:NSLocalizedString(@"Website", nil),
-                                                                NSLocalizedString(@"Legal", nil),
-                                                                NSLocalizedString(@"Support", nil), nil];
-    [aboutView show];
+    UIAlertController* aboutAlert = [UIAlertController alertControllerWithTitle:aboutTitle message:aboutMessage preferredStyle:UIAlertControllerStyleAlert];
+    
+    [aboutAlert addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                    style:UIAlertActionStyleCancel
+                                                  handler:nil]];
+    [aboutAlert addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"Website", nil)
+                                                    style:UIAlertActionStyleDefault
+                                                  handler:^(UIAlertAction * _Nonnull action) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.mumbleapp.com/"]];
+    }]];
+    [aboutAlert addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"Legal", nil)
+                                                    style:UIAlertActionStyleDefault
+                                                  handler:^(UIAlertAction * _Nonnull action) {
+        MULegalViewController *legalView = [[MULegalViewController alloc] init];
+        UINavigationController *navController = [[UINavigationController alloc] init];
+        [navController pushViewController:legalView animated:NO];
+        [[self navigationController] presentViewController:navController animated:YES completion:nil];
+    }]];
+    [aboutAlert addAction: [UIAlertAction actionWithTitle:NSLocalizedString(@"Support", nil)
+                                                    style:UIAlertActionStyleDefault
+                                                  handler:^(UIAlertAction * _Nonnull action) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"mailto:support@mumbleapp.com"]];
+    }]];
+    
+    [self presentViewController:aboutAlert animated:YES completion:nil];
 }
 
 - (void) prefsClicked:(id)sender {
     MUPreferencesViewController *prefs = [[MUPreferencesViewController alloc] init];
     [self.navigationController pushViewController:prefs animated:YES];
-}
-
-#pragma mark -
-#pragma mark About Dialog
-
-- (void) alertView:(UIAlertView *)alert didDismissWithButtonIndex:(NSInteger)buttonIndex {
-    if (buttonIndex == 1) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://www.mumbleapp.com/"]];
-    } else if (buttonIndex == 2) {
-        MULegalViewController *legalView = [[MULegalViewController alloc] init];
-        UINavigationController *navController = [[UINavigationController alloc] init];
-        [navController pushViewController:legalView animated:NO];
-        [[self navigationController] presentViewController:navController animated:YES completion:nil];
-    } else if (buttonIndex == 3) {
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"mailto:support@mumbleapp.com"]];
-    }
 }
 
 @end


### PR DESCRIPTION
Fixes most of #152 

UIAlertController needs us to handle presentation explicitly, whereas the old APIs just had a magic "show" method. This can complicate usage where there's no UIViewController available to present the UIAlertController for us, but it seems like the magic method invites behavior that's harder to debug.

Two instances of UIAlertView remain in MUCertificateCreationView and MUCertificateDiskImportViewController - They use a static helper function that goes through GCD and I don't trust my knowledge to properly rewrite and test it right now, so I'll leave that for another day.

MUConnectionController also turned out quite challenging; there's this "Connecting..." alert that shows right until the server UI pops up. Dismissing and then immediately presenting another view controller does not work because it's done asynchronously, therefore we have to use a completion handler to make it work properly.