### PR TITLE
Unify navbar styling

### DIFF
--- a/Source/Classes/MUAccessTokenViewController.m
+++ b/Source/Classes/MUAccessTokenViewController.m
@@ -34,14 +34,6 @@
     [super viewWillAppear:animated];
 
     [[self navigationItem] setTitle:NSLocalizedString(@"Access Tokens", nil)];
-
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
     
     if (@available(iOS 7, *)) {
         self.tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLine;

--- a/Source/Classes/MUAdvancedAudioPreferencesViewController.m
+++ b/Source/Classes/MUAdvancedAudioPreferencesViewController.m
@@ -27,14 +27,6 @@
 
     self.title = NSLocalizedString(@"Advanced Audio", nil);
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     
     if (@available(iOS 7, *)) {

--- a/Source/Classes/MUApplicationDelegate.m
+++ b/Source/Classes/MUApplicationDelegate.m
@@ -101,6 +101,12 @@
     // XXX: don't do it system-wide just yet
     //    _window.tintColor = [UIColor whiteColor];
     }
+
+    UINavigationBar.appearance.tintColor = [UIColor whiteColor];
+    UINavigationBar.appearance.translucent = NO;
+    UINavigationBar.appearance.barTintColor = [UIColor blackColor];
+    UINavigationBar.appearance.backgroundColor = [UIColor blackColor];
+    UINavigationBar.appearance.barStyle = UIBarStyleBlack;
     
     // Put a background view in here, to have prettier transitions.
     [_window addSubview:[MUBackgroundView backgroundView]];

--- a/Source/Classes/MUAudioQualityPreferencesViewController.m
+++ b/Source/Classes/MUAudioQualityPreferencesViewController.m
@@ -22,14 +22,6 @@
     
     self.title = NSLocalizedString(@"Audio Quality", nil);
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     
     if (@available(iOS 7, *)) {

--- a/Source/Classes/MUAudioSidetonePreferencesViewController.m
+++ b/Source/Classes/MUAudioSidetonePreferencesViewController.m
@@ -21,14 +21,6 @@
     [super viewWillAppear:animated];
     
     self.title = NSLocalizedString(@"Sidetone", nil);
-
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
     
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     

--- a/Source/Classes/MUAudioTransmissionPreferencesViewController.m
+++ b/Source/Classes/MUAudioTransmissionPreferencesViewController.m
@@ -34,14 +34,6 @@
 
     self.title = NSLocalizedString(@"Transmission", nil);
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     
     if (@available(iOS 7, *)) {

--- a/Source/Classes/MUCertificateCreationView.m
+++ b/Source/Classes/MUCertificateCreationView.m
@@ -114,14 +114,6 @@ static void ShowAlertDialog(NSString *title, NSString *msg) {
                                           @"Title of MUCertificateCreationView (shown when creating a self-signed certificate)");
     [self setTitle:newCert];
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     
     if (@available(iOS 7, *)) {

--- a/Source/Classes/MUCertificateDiskImportViewController.m
+++ b/Source/Classes/MUCertificateDiskImportViewController.m
@@ -69,14 +69,6 @@ static void ShowAlertDialog(NSString *title, NSString *msg) {
 - (void) viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
 
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-
     if (self.tableView.style == UITableViewStyleGrouped) {
         self.tableView.backgroundView = [MUBackgroundView backgroundView];
     } else {

--- a/Source/Classes/MUCertificatePreferencesViewController.m
+++ b/Source/Classes/MUCertificatePreferencesViewController.m
@@ -42,14 +42,6 @@
     [super viewWillAppear:animated];
 
     self.navigationItem.title = NSLocalizedString(@"Certificates", nil);
-
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
     
     if (@available(iOS 7, *)) {
         self.tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLine;

--- a/Source/Classes/MUCertificateViewController.m
+++ b/Source/Classes/MUCertificateViewController.m
@@ -104,14 +104,6 @@ static const NSUInteger CertificateViewSectionTotal              = 4;
         [_arrows addTarget:self action:@selector(certificateSwitch:) forControlEvents:UIControlEventValueChanged];
     }
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     
     if (@available(iOS 7, *)) {

--- a/Source/Classes/MUCountryServerListController.m
+++ b/Source/Classes/MUCountryServerListController.m
@@ -55,14 +55,6 @@
     self.navigationItem.titleView = nil;
     self.navigationItem.title = _countryName;
     self.navigationItem.hidesBackButton = NO;
-    
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
 
     if (@available(iOS 7, *)) {
         _tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLine;

--- a/Source/Classes/MUFavouriteServerEditViewController.m
+++ b/Source/Classes/MUFavouriteServerEditViewController.m
@@ -194,14 +194,6 @@
 - (void) viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     
     if (@available(iOS 7, *)) {

--- a/Source/Classes/MUFavouriteServerListController.m
+++ b/Source/Classes/MUFavouriteServerListController.m
@@ -52,14 +52,6 @@
 
     [[self navigationItem] setTitle:NSLocalizedString(@"Favourite Servers", nil)];
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     if (@available(iOS 7, *)) {
         self.tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLine;
         self.tableView.separatorInset = UIEdgeInsetsZero;

--- a/Source/Classes/MUImageViewController.m
+++ b/Source/Classes/MUImageViewController.m
@@ -68,14 +68,6 @@
     
     self.navigationItem.title = [NSString stringWithFormat:NSLocalizedString(@"%lu of %lu", nil), (unsigned long)1, (unsigned long)[_images count]];
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     if (@available(iOS 7, *)) {
         _scrollView.backgroundColor = [MUColor backgroundViewiOS7Color];
     }

--- a/Source/Classes/MULanServerListController.m
+++ b/Source/Classes/MULanServerListController.m
@@ -49,14 +49,6 @@ static NSInteger NetServiceAlphabeticalSort(id arg1, id arg2, void *reverse) {
     [super viewWillAppear:YES];
     [[self navigationItem] setTitle:NSLocalizedString(@"LAN Servers", nil)];
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     if (@available(iOS 7, *)) {
         self.tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLine;
         self.tableView.separatorInset = UIEdgeInsetsZero;

--- a/Source/Classes/MULegalViewController.m
+++ b/Source/Classes/MULegalViewController.m
@@ -22,14 +22,6 @@
 
 - (void) viewWillAppear:(BOOL)animated {
     self.navigationItem.title = NSLocalizedString(@"Legal", nil);
-
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
     
     UIBarButtonItem *done = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneButtonClicked:)];
     self.navigationItem.rightBarButtonItem = done;

--- a/Source/Classes/MUMessageAttachmentViewController.m
+++ b/Source/Classes/MUMessageAttachmentViewController.m
@@ -30,14 +30,6 @@
     [super viewWillAppear:animated];
 
     self.navigationItem.title = NSLocalizedString(@"Attachments", nil);
-
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
     
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     

--- a/Source/Classes/MUMessageRecipientViewController.m
+++ b/Source/Classes/MUMessageRecipientViewController.m
@@ -95,14 +95,6 @@
 
     self.navigationItem.title = NSLocalizedString(@"Message Recipient", nil);
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     if (@available(iOS 7, *)) {
         self.tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLine;
         self.tableView.separatorInset = UIEdgeInsetsZero;

--- a/Source/Classes/MUMessagesViewController.m
+++ b/Source/Classes/MUMessagesViewController.m
@@ -208,14 +208,6 @@ static UIView *MUMessagesViewControllerFindUIView(UIView *rootView, NSString *pr
 - (void) viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
     

--- a/Source/Classes/MUPreferencesViewController.m
+++ b/Source/Classes/MUPreferencesViewController.m
@@ -53,14 +53,6 @@
         [self.navigationController.navigationBar setBackgroundImage:[MUImage clearColorImage] forBarMetrics:UIBarMetricsDefault];
         self.navigationController.navigationBar.translucent = YES;
     }
- 
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
     
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     

--- a/Source/Classes/MUPublicServerListController.m
+++ b/Source/Classes/MUPublicServerListController.m
@@ -27,14 +27,6 @@
     [super viewWillAppear:YES];
 
     self.navigationItem.title = NSLocalizedString(@"Public Servers", nil);
-
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
     
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     

--- a/Source/Classes/MURemoteControlPreferencesViewController.m
+++ b/Source/Classes/MURemoteControlPreferencesViewController.m
@@ -23,14 +23,6 @@
 
 - (void) viewWillAppear:(BOOL)animated {
     self.navigationItem.title = NSLocalizedString(@"Remote Control", nil);
-
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
     
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     

--- a/Source/Classes/MUServerRootViewController.m
+++ b/Source/Classes/MUServerRootViewController.m
@@ -105,14 +105,6 @@
     _numberBadgeView.hidden = _unreadMessages == 0;
     
     [self setViewControllers:[NSArray arrayWithObject:_serverView] animated:NO];
-    
-    UINavigationBar *navBar = self.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
 
     self.toolbar.barStyle = UIBarStyleBlackOpaque;
 }

--- a/Source/Classes/MUServerViewController.m
+++ b/Source/Classes/MUServerViewController.m
@@ -88,14 +88,6 @@
 
 - (void) viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
     
     if (@available(iOS 7, *)) {
         self.tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLine;

--- a/Source/Classes/MUVoiceActivitySetupViewController.m
+++ b/Source/Classes/MUVoiceActivitySetupViewController.m
@@ -25,14 +25,6 @@
     
     self.navigationItem.title = NSLocalizedString(@"Voice Activity", nil);
     
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-    
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     
     if (@available(iOS 7, *)) {

--- a/Source/Classes/MUWelcomeScreenPhone.m
+++ b/Source/Classes/MUWelcomeScreenPhone.m
@@ -38,14 +38,6 @@
     self.navigationItem.title = @"Mumble";
     self.navigationController.toolbarHidden = YES;
 
-    UINavigationBar *navBar = self.navigationController.navigationBar;
-    if (@available(iOS 7, *)) {
-        navBar.tintColor = [UIColor whiteColor];
-        navBar.translucent = NO;
-        navBar.backgroundColor = [UIColor blackColor];
-    }
-    navBar.barStyle = UIBarStyleBlackOpaque;
-
     self.tableView.backgroundView = [MUBackgroundView backgroundView];
     
     if (@available(iOS 7, *)) {


### PR DESCRIPTION
After iOS 7 was introduced, navigation bars were styled manually in each view controller (8fd4f487bee55ad99a8876c5f3e8214146aa8baa).

This can be done globally, by using UINavigationBar's appearance member.
While we're at it, change to UIBarStyleBlack as UIBarStyleBlackOpaque is deprecated since iOS 13 and does not make a difference from what I can tell.

Fixes #176.



