### PR TITLE
Notification permissions

### DIFF
--- a/Source/Classes/MUApplicationDelegate.m
+++ b/Source/Classes/MUApplicationDelegate.m
@@ -17,6 +17,8 @@
 #import <MumbleKit/MKAudio.h>
 #import <MumbleKit/MKVersion.h>
 
+@import UserNotifications;
+
 @interface MUApplicationDelegate () <UIApplicationDelegate,
                                      UIAlertViewDelegate> {
     UIWindow                  *_window;
@@ -39,6 +41,14 @@
     
     // Initialize the notification controller
     [MUNotificationController sharedController];
+    
+    // Request notification permissions
+    [[UNUserNotificationCenter currentNotificationCenter]
+        requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionBadge | UNAuthorizationOptionSound)
+        completionHandler:^(BOOL granted, NSError *error) {
+            // Permission prompt shown on first launch
+            [[NSUserDefaults standardUserDefaults] setBool:granted forKey:@"NotificationsEnabled"];
+    }];
     
     // Try to fetch an updated public server list
     _publistFetcher = [[MUPublicServerListFetcher alloc] init];

--- a/Source/Classes/MUPreferencesViewController.m
+++ b/Source/Classes/MUPreferencesViewController.m
@@ -17,6 +17,8 @@
 
 #import <MumbleKit/MKCertificate.h>
 
+@import UserNotifications;
+
 @interface MUPreferencesViewController () {
     UITextField *_activeTextField;
 }
@@ -83,7 +85,7 @@
 #pragma mark Table view data source
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return 2;
+    return 3;
 }
 
 - (NSInteger) tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
@@ -97,6 +99,9 @@
 #else
         return 2;
 #endif
+    // Notifications
+    } else if (section == 2) {
+        return 2;
     }
 
     return 0;
@@ -187,6 +192,40 @@
             cell.selectionStyle = UITableViewCellSelectionStyleGray;
             return cell;
         }
+    } else if ([indexPath section] == 2) {
+        if ([indexPath row] == 0) {
+            UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"NotificationStateCell"];
+            if (cell == nil)
+                cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"NotificationStateCell"];
+            cell.accessoryType = UITableViewCellAccessoryNone;
+            cell.textLabel.text = NSLocalizedString(@"Enabled", nil);
+            cell.selectionStyle = UITableViewCellSelectionStyleNone;
+            
+            UILabel *yesnoText = [[UILabel alloc] init];
+            yesnoText.text = NSLocalizedString(@"Yes", nil);
+            
+            cell.detailTextLabel.text = NSLocalizedString(@"Yes", nil);
+            cell.detailTextLabel.textColor = [MUColor selectedTextColor];
+            
+            [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *settings) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (settings.authorizationStatus == UNAuthorizationStatusDenied) {
+                        yesnoText.text = NSLocalizedString(@"No", nil);
+                        cell.detailTextLabel.text = NSLocalizedString(@"No", nil);
+                    }
+                });
+            }];
+            
+            return cell;
+        } else if ([indexPath row] == 1) {
+            cell.textLabel.text = NSLocalizedString(@"Open settings", "Label for a button that opens the app's notification settings in the Settings app");
+            
+            cell.textLabel.textAlignment = NSTextAlignmentCenter;
+            cell.selectionStyle = UITableViewCellSelectionStyleNone;
+            // TODO: HACK, replace with [UIColor linkColor] on iOS 13+. For now it's close enough.
+            cell.textLabel.textColor = [UIColor colorWithRed:16.0f/255.0f green:33.0f/255.0f blue:204.0f/255.0f alpha:1.0f];
+            return cell;
+        }
     }
 
     return cell;
@@ -197,6 +236,8 @@
         return [MUTableViewHeaderLabel labelWithText:NSLocalizedString(@"Audio", nil)];
     } else if (section == 1) {
         return [MUTableViewHeaderLabel labelWithText:NSLocalizedString(@"Network", nil)];
+    } else if (section == 2) {
+        return [MUTableViewHeaderLabel labelWithText:NSLocalizedString(@"Notifications", nil)];
     }
 
     return nil;
@@ -226,6 +267,14 @@
         if ([indexPath row] == 2) { // Remote Control
             MURemoteControlPreferencesViewController *remoteControlPref = [[MURemoteControlPreferencesViewController alloc] init];
             [self.navigationController pushViewController:remoteControlPref animated:YES];
+        }
+    } else if ([indexPath section] == 2) { // Notifications
+        if ([indexPath row] == 1) { // Open Settings
+            NSURL *settingsURL = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+            if (@available(iOS 15.4, *)) {
+                settingsURL = [NSURL URLWithString:UIApplicationOpenNotificationSettingsURLString];
+            }
+            [[UIApplication sharedApplication] openURL:settingsURL options:@{} completionHandler:nil];
         }
     }
 }


### PR DESCRIPTION
closes #161 

This is a 90% solution, with one minor issue.

After coming back from the settings, the displayed permission status is not updated (which would require reacting to coming back to foreground and plumbing it through). I think this is okay enough for now